### PR TITLE
Avoid existential type BuildInfo[_]

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -5,11 +5,18 @@ sbt-buildinfo
 
 sbt-buildinfo generates Scala source from your build definitions.
 
-Latest
-------
+Latest Stable
+-------------
 
 ```scala
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.1.2")
+```
+
+Latest Snapshot
+---------------
+
+```scala
+addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.2.1-SNAPSHOT")
 ```
 
 Usage
@@ -44,13 +51,15 @@ Customize `buildInfoKeys` by adding whatever keys. You can use `BuildInfo.map` t
 name and value, or add new fields with tuples:
 
 ```scala
-buildInfoKeys ++= Seq(
+buildInfoKeys ++= Seq[BuildInfo](
   resolvers,
   libraryDependencies in Test,
   "custom" -> 1234,
   BuildInfo.map(name) { case (k, v) => "project" + k.capitalize -> v.capitalize }
 )
 ```
+
+(__Note__: in version 0.1.2, you need to use `Seq[Scoped]` instead)
 
 This generates:
 
@@ -66,14 +75,14 @@ Tasks can be added only if they do not depend on `sourceGenerators`. Otherwise, 
 Here's how to change the generated the object name:
 
 ```scala
-buildInfoObject  := "Info"
+buildInfoObject := "Info"
 ```
 
-This change to `object Info`. Changing the object name is optional, but to avoid name clash with other jars, package name should be changed.
+This changes the generated object to `object Info`. Changing the object name is optional, but to avoid name clash with other jars, package name should be unique.
 
 ### build number
 
-A build number can be generated as follows. Note that cross building against multiple Scala would each generate new number.
+A build number can be generated as follows. Note that cross building against multiple Scala would each generate a new number.
 
 ```scala
 buildInfoKeys += buildInfoBuildNumber

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ name := "sbt-buildinfo"
 
 organization := "com.eed3si9n"
 
-version := "0.2.0-SNAPSHOT"
+version := "0.2.1-SNAPSHOT"
 
 description := "sbt plugin to generate build info"
 

--- a/src/sbt-test/sbt-buildinfo/append/build.sbt
+++ b/src/sbt-test/sbt-buildinfo/append/build.sbt
@@ -8,7 +8,7 @@ buildInfoSettings
 
 sourceGenerators in Compile <+= buildInfo
 
-buildInfoKeys ++= Seq[BuildInfo[_]](name, organization, version, scalaVersion,
+buildInfoKeys ++= Seq[BuildInfo](name, organization, version, scalaVersion,
   libraryDependencies, libraryDependencies in Test)
 
 buildInfoKeys += BuildInfo(resolvers)

--- a/src/sbt-test/sbt-buildinfo/append/project/plugins.sbt
+++ b/src/sbt-test/sbt-buildinfo/append/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.2.0-SNAPSHOT")
+addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.2.1-SNAPSHOT")

--- a/src/sbt-test/sbt-buildinfo/multi/project/plugins.sbt
+++ b/src/sbt-test/sbt-buildinfo/multi/project/plugins.sbt
@@ -1,3 +1,3 @@
-addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.2.0-SNAPSHOT")
+addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.2.1-SNAPSHOT")
 
 // libraryDependencies += Defaults.sbtPluginExtra("com.eed3si9n" % "sbt-buildinfo" % "0.1.1-SNAPSHOT", "0.12.0-M2", "2.9.1")

--- a/src/sbt-test/sbt-buildinfo/simple/project/plugins.sbt
+++ b/src/sbt-test/sbt-buildinfo/simple/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.2.0-SNAPSHOT")
+addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.2.1-SNAPSHOT")


### PR DESCRIPTION
I tried with the type alias `BuildInfo` now -- it seems to work fine with all three tests. So for append, we need the explicit type `Seq[BuildInfo]`.

Had to increase the minor version (now 0.2.1-SNAPSHOT), because I couldn't wipe the cached version somehow. You can revert that if necessary.
