### PR TITLE
attended to some deprecation warnings

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,6 +10,8 @@ sbtVersion in Global := "0.13.0"
 
 scalaVersion in Global := "2.10.2"
 
+scalacOptions := Seq("-unchecked", "-deprecation")
+
 description := "sbt plugin to generate build info"
 
 licenses := Seq("MIT License" -> url("https://github.com/sbt/sbt-buildinfo/blob/master/LICENSE"))

--- a/src/main/scala/sbtbuildinfo/Plugin.scala
+++ b/src/main/scala/sbtbuildinfo/Plugin.scala
@@ -125,7 +125,7 @@ object Plugin extends sbt.Plugin {
 
       def getType(info: BuildInfoKey): Option[String] = {
         val mf = info.manifest
-        if(mf.erasure == classOf[Option[_]]) {
+        if(mf.runtimeClass == classOf[Option[_]]) {
           val s = mf.toString
           Some(if( s.startsWith("scala.")) s.substring(6) else s)
         } else None
@@ -165,11 +165,11 @@ object Plugin extends sbt.Plugin {
     current
   }
 
-  lazy val buildInfoSettings: Seq[Project.Setting[_]] = Seq(
+  lazy val buildInfoSettings: Seq[Def.Setting[_]] = Seq(
     buildInfo <<= (sourceManaged in Compile,
-        buildInfoObject, buildInfoPackage, buildInfoKeys, thisProjectRef, state, cacheDirectory) map {
-      (dir, obj, pkg, keys, ref, state, cacheDir) =>
-      Seq(BuildInfo(dir / "sbt-buildinfo", obj, pkg, keys, ref, state, cacheDir))
+        buildInfoObject, buildInfoPackage, buildInfoKeys, thisProjectRef, state, streams) map {
+      (dir, obj, pkg, keys, ref, state, taskStreams) =>
+      Seq(BuildInfo(dir / "sbt-buildinfo", obj, pkg, keys, ref, state, taskStreams.cacheDirectory))
     },
     buildInfoObject  := "BuildInfo",
     buildInfoPackage := "buildinfo",


### PR DESCRIPTION
Hi,

I took the liberty to attend to some deprecation warnings in the hope that you'd find that useful. The only change that is visible to users of the plug-in should be the change from `Project.Setting` to `Def.Setting` because the former caused a deprecation warning in the dependent build.
