### PR TITLE
file paths are now escaped to support windows paths

### DIFF
--- a/src/main/scala/sbtbuildinfo/Plugin.scala
+++ b/src/main/scala/sbtbuildinfo/Plugin.scala
@@ -136,17 +136,19 @@ object Plugin extends sbt.Plugin {
         case x: Long => x.toString + "L"
         case x: Double => x.toString
         case x: Boolean => x.toString
-        case x: File => "\"%s\"" format escapeFilePath(x)
         case node: scala.xml.NodeSeq if node.toString.trim.nonEmpty => node.toString
         case (k, _v) => "(%s -> %s)" format(quote(k), quote(_v))
         case mp: Map[_, _] => mp.toList.map(quote(_)).mkString("Map(", ", ", ")")
         case seq: Seq[_]   => seq.map(quote(_)).mkString("Seq(", ", ", ")")
         case op: Option[_] => op map { x => "Some(" + quote(x) + ")" } getOrElse {"None"}
-        case url: java.net.URL => "new java.net.URL(\"%s\")" format url.toString
-        case s => "\"%s\"" format s.toString
+        case url: java.net.URL => "new java.net.URL(\"%s\")" format quote(url.toString)
+        case file: File => "new java.io.File(\"%s\")" format quote(file.toString)
+        case s => "\"%s\"" format encodeStringLiteral(s.toString)
       }
 
-      private def escapeFilePath(file: File): String = file.toString.replaceAll("\\\\", "\\\\\\\\")
+      def encodeStringLiteral(str: String): String =
+        str.replace("\\","\\\\").replace("\n","\\n").replace("\b","\\b").replace("\r","\\r").
+          replace("\t","\\t").replace("\'","\\'").replace("\f","\\f").replace("\"","\\\"")
     }
   }
 


### PR DESCRIPTION
When exporting a file setting in the build-info on a windows machine, the file path gets now escaped in oder to get a valid scala string in BuildInfo scala object. 
