### PR TITLE
Added a toMap() method to BuildInfo which can be used to get a Map[String, Any] of all BuildInfo fields.

### DIFF
--- a/src/sbt-test/sbt-buildinfo/append/build.sbt
+++ b/src/sbt-test/sbt-buildinfo/append/build.sbt
@@ -39,6 +39,16 @@ TaskKey[Unit]("check") <<= (sourceManaged in Compile) map { (dir) =>
          """  val test_libraryDependencies = Seq("org.scala-lang:scala-library:2.10.2")""" ::
          """  val resolvers = Seq("Sonatype Public: https://oss.sonatype.org/content/groups/public")""" ::
          """  override val toString = "name: %s, version: %s, scalaVersion: %s, sbtVersion: %s, organization: %s, libraryDependencies: %s, test_libraryDependencies: %s, resolvers: %s" format (name, version, scalaVersion, sbtVersion, organization, libraryDependencies, test_libraryDependencies, resolvers)""" ::
+         "" ::
+         """  val toMap = Map[String, Any](""" ::
+         """    "name" -> name,""" ::
+         """    "version" -> version,""" ::
+         """    "scalaVersion" -> scalaVersion,""" ::
+         """    "sbtVersion" -> sbtVersion,""" ::
+         """    "organization" -> organization,""" ::
+         """    "libraryDependencies" -> libraryDependencies,""" ::
+         """    "test_libraryDependencies" -> test_libraryDependencies,""" ::
+         """    "resolvers" -> resolvers)""" ::
          """}""" :: Nil =>
     case _ => sys.error("unexpected output: \n" + lines.mkString("\n"))
   }

--- a/src/sbt-test/sbt-buildinfo/caching/build.sbt
+++ b/src/sbt-test/sbt-buildinfo/caching/build.sbt
@@ -26,6 +26,10 @@ TaskKey[Unit]("check") <<= (sourceManaged in Compile) map { (dir) =>
          """  val name = "helloworld"""" ::
          """  val version = "0.1"""" ::
          """  override val toString = "name: %s, version: %s" format (name, version)""" ::
+         "" ::
+         """  val toMap = Map[String, Any](""" ::
+         """    "name" -> name,""" ::
+         """    "version" -> version)""" ::
          """}""" :: Nil =>
     case _ => sys.error("unexpected output: \n" + lines.mkString("\n"))
   }

--- a/src/sbt-test/sbt-buildinfo/multi/project/build.scala
+++ b/src/sbt-test/sbt-buildinfo/multi/project/build.scala
@@ -39,6 +39,13 @@ object Build extends sbt.Build {
              """  val homepage = new java.net.URL("http://example.com")""" ::
              """  val scalaVersion = "2.10.2"""" ::
              """  override val toString = "name: %s, projectId: %s, version: %s, homepage: %s, scalaVersion: %s" format (name, projectId, version, homepage, scalaVersion)""" ::
+             "" ::
+             """  val toMap = Map[String, Any](""" ::
+             """    "name" -> name,""" ::
+             """    "projectId" -> projectId,""" ::
+             """    "version" -> version,""" ::
+             """    "homepage" -> homepage,""" ::
+             """    "scalaVersion" -> scalaVersion)""" ::
              """}""" :: Nil =>
         case _ => sys.error("unexpected output: " + lines.mkString("\n"))
       }

--- a/src/sbt-test/sbt-buildinfo/simple/build.sbt
+++ b/src/sbt-test/sbt-buildinfo/simple/build.sbt
@@ -49,6 +49,19 @@ check := {
          """  val buildTime = 1234L""" ::
          targetInfo :: // """
          """  override val toString = "name: %s, projectVersion: %s, scalaVersion: %s, ivyXml: %s, homepage: %s, licenses: %s, isSnapshot: %s, year: %s, sym: %s, buildTime: %s, target: %s" format (name, projectVersion, scalaVersion, ivyXml, homepage, licenses, isSnapshot, year, sym, buildTime, target)""" ::
+         "" ::
+         """  val toMap = Map[String, Any](""" ::
+         """    "name" -> name,""" ::
+         """    "projectVersion" -> projectVersion,""" ::
+         """    "scalaVersion" -> scalaVersion,""" ::
+         """    "ivyXml" -> ivyXml,""" ::
+         """    "homepage" -> homepage,""" ::
+         """    "licenses" -> licenses,""" ::
+         """    "isSnapshot" -> isSnapshot,""" ::
+         """    "year" -> year,""" ::
+         """    "sym" -> sym,""" ::
+         """    "buildTime" -> buildTime,""" ::
+         """    "target" -> target)""" ::
          """}""" :: Nil if (targetInfo contains "val target = new java.io.File(") =>
     case _ => sys.error("unexpected output: \n" + lines.mkString("\n"))
   }


### PR DESCRIPTION
The immutable map is generated once and stored in the lazy val keyValueMap, so repeated calls of toMap() should be very fast.
