### PR TITLE
Specify SBT version for append test

### DIFF
--- a/src/sbt-test/sbt-buildinfo/append/project/build.properties
+++ b/src/sbt-test/sbt-buildinfo/append/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.7


### PR DESCRIPTION
The append test expects to see a specific sbtVersion. We specify 0.13.7
in build.properties so that running the test on different SBT version
won't fail.