### PR TITLE
Write a trailing newline to the end of a generated build info file

### DIFF
--- a/src/main/scala/sbtbuildinfo/BuildInfo.scala
+++ b/src/main/scala/sbtbuildinfo/BuildInfo.scala
@@ -62,7 +62,7 @@ object BuildInfo {
       val distinctKeys = makeKeys
       val values = distinctKeys.flatMap(entry(_))
       val lines = renderer.header ++ renderer.renderKeys(values) ++ renderer.footer
-      IO.write(file, lines.mkString("\n"))
+      IO.write(file, lines.mkString("\n") + "\n")
       file
     }
 


### PR DESCRIPTION
This PR scratches a longstanding itch for me. Hopefully this scratches a common itch for others.

This change modifies the build info writer to add a trailing newline to the generated file.

  1. This makes the `org.scalastyle.file.NewLineAtEofChecker` scalastyle rule happy. (The Spark project uses this rule, for example.)
  1. This makes the generated file behave better for unix CLI tools. For example, `cat` will write a trailing newline at the end of output instead of abutting the end of the file with the beginning of the shell prompt.

How does this sound?