### PR TITLE
Writing lines to BuildInfo.scala, reloaded

### DIFF
--- a/src/main/scala/sbtbuildinfo/BuildInfo.scala
+++ b/src/main/scala/sbtbuildinfo/BuildInfo.scala
@@ -62,7 +62,7 @@ object BuildInfo {
       val distinctKeys = makeKeys
       val values = distinctKeys.flatMap(entry(_))
       val lines = renderer.header ++ renderer.renderKeys(values) ++ renderer.footer
-      IO.write(file, lines.mkString("\n") + "\n")
+      IO.writeLines(file, lines)
       file
     }
 


### PR DESCRIPTION
Instead of

```IO.write(file, lines.mkString("\n") + "\n")```

use

```IO.writeLines(file, lines)```

This is a cleaner approach because `IO.writeLines` uses platform-specific line endings.