### PR TITLE
Feature/build info values

### DIFF
--- a/notes/0.6.0.markdown
+++ b/notes/0.6.0.markdown
@@ -9,7 +9,7 @@
 
 ### buildInfoUsePackageAsPath
 
-sbt-buildinfo 0.6.0 adds a new settting called `buildInfoUsePackageAsPath`.
+sbt-buildinfo 0.6.0 adds a new setting called `buildInfoUsePackageAsPath`.
 When set to `true`, the generated file will be placed in the directory structure matching the package name, for instance `target/scala-2.10/src_managed/main/x/y/z/BuildInfo.scala` for the package `x.y.z`. This is aimed to work around the IDEs that demand the file position to match the package namespace.
 
 This feature was contributed as [#75][75] by [@peter-fu][@peter-fu].

--- a/notes/0.6.2.markdown
+++ b/notes/0.6.2.markdown
@@ -1,0 +1,5 @@
+
+### buildInfoValues
+
+Adds `buildInfoValues` task, which exposes the set of `BuildInfoResult` objects used by sbt-buildinfo to generate BuildInfo files. 
+This can be used within the sbt build itself to add the build info to the jar Manifest.

--- a/src/main/scala/sbtbuildinfo/BuildInfo.scala
+++ b/src/main/scala/sbtbuildinfo/BuildInfo.scala
@@ -10,6 +10,67 @@ object BuildInfo {
             proj: ProjectRef, state: State, cacheDir: File): File =
     BuildInfoTask(dir, renderer, obj, keys, options, proj, state, cacheDir).file
 
+  private def extraKeys(options: Seq[BuildInfoOption]): Seq[BuildInfoKey] =
+      if (options contains BuildInfoOption.BuildTime) {
+        val now = System.currentTimeMillis()
+        val dtf = new java.text.SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS")
+        dtf.setTimeZone(java.util.TimeZone.getTimeZone("UTC"))
+        val nowStr = dtf.format(new java.util.Date(now))
+        Seq[BuildInfoKey](
+          "builtAtString" -> nowStr,
+          "builtAtMillis" -> now
+        )
+      } else {
+        Seq.empty[BuildInfoKey]
+      }
+
+  def results(keys: Seq[BuildInfoKey], options: Seq[BuildInfoOption], project: ProjectRef, state: State): Seq[BuildInfoResult] = {
+    val distinctKeys = (keys ++ extraKeys(options)).toList.distinct
+    val extracted = Project.extract(state)
+
+    def entry[A](info: BuildInfoKey.Entry[A]): Option[BuildInfoResult] = {
+      val typeExpr = TypeExpression.parse(info.manifest.toString())._1
+      val result = info match {
+        case BuildInfoKey.Setting(key) => extracted getOpt (key in scope(key, project)) map {
+          ident(key) -> _
+        }
+        case BuildInfoKey.Task(key) => Some(ident(key) -> extracted.runTask(key in scope(key, project), state)._2)
+        case BuildInfoKey.Constant(tuple) => Some(tuple)
+        case BuildInfoKey.Action(name, fun) => Some(name -> fun.apply)
+        case BuildInfoKey.Mapped(from, fun) => entry(from).map { r => fun((r.identifier, r.value.asInstanceOf[A])) }
+      }
+      result.map { case (identifier,value) => BuildInfoResult(identifier, value, typeExpr) }
+    }
+
+    distinctKeys.flatMap(entry(_))
+  }
+
+  private def scope(scoped: Scoped, project: ProjectReference) = {
+    val scope0 = scoped.scope
+    if (scope0.project == This) scope0 in project
+    else scope0
+  }
+
+  private def ident(scoped: Scoped): String = {
+    val scope = scoped.scope
+    (scope.config.toOption match {
+      case None => ""
+      case Some(ConfigKey("compile")) => ""
+      case Some(ConfigKey(x)) => x + "_"
+    }) +
+      (scope.task.toOption match {
+        case None => ""
+        case Some(x) => x.label + "_"
+      }) +
+      (scoped.key.label.split("-").toList match {
+        case Nil => ""
+        case x :: xs => x + (xs map {
+          _.capitalize
+        }).mkString("")
+      })
+  }
+
+
   private case class BuildInfoTask(dir: File,
                                    renderer: BuildInfoRenderer,
                                    obj: String,
@@ -18,10 +79,10 @@ object BuildInfo {
                                    proj: ProjectRef,
                                    state: State,
                                    cacheDir: File) {
+
     import FileInfo.hash
     import Tracked.inputChanged
 
-    def extracted = Project.extract(state)
     val tempFile = cacheDir / "sbt-buildinfo" / s"$obj.${renderer.extension}"
     val outFile = dir / s"$obj.${renderer.extension}"
 
@@ -40,65 +101,13 @@ object BuildInfo {
         } // if
       }
 
-    def makeKeys : List[BuildInfoKey] = {
-      val extraKeys = {
-        if (options contains BuildInfoOption.BuildTime) {
-          val now = System.currentTimeMillis()
-          val dtf = new java.text.SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS")
-          dtf.setTimeZone(java.util.TimeZone.getTimeZone("UTC"))
-          val nowStr = dtf.format(new java.util.Date(now))
-          Seq[BuildInfoKey] (
-            "builtAtString" -> nowStr ,
-            "builtAtMillis" -> now
-          )
-        } else {
-          Seq.empty[BuildInfoKey]
-        }
-      }
-      (keys ++ extraKeys).toList.distinct
-    }
-
     def makeFile(file: File): File = {
-      val distinctKeys = makeKeys
-      val values = distinctKeys.flatMap(entry(_))
+      val values = results(keys, options, proj, state)
       val lines = renderer.header ++ renderer.renderKeys(values) ++ renderer.footer
       IO.writeLines(file, lines, IO.utf8)
       file
     }
 
-    def entry[A](info: BuildInfoKey.Entry[A]): Option[BuildInfoResult] = {
-      val typeExpr = TypeExpression.parse(info.manifest.toString())._1
-      val result = info match {
-        case BuildInfoKey.Setting(key)      => extracted getOpt (key in scope(key)) map { ident(key) -> _ }
-        case BuildInfoKey.Task(key)         => Some(ident(key) -> extracted.runTask(key in scope(key), state)._2)
-        case BuildInfoKey.Constant(tuple)   => Some(tuple)
-        case BuildInfoKey.Action(name, fun) => Some(name -> fun.apply)
-        case BuildInfoKey.Mapped(from, fun) => entry(from).map { r => fun(r.identifier -> r.value.asInstanceOf[A]) }
-      }
-      result.map(r => BuildInfoResult(r._1, r._2, typeExpr))
-    }
-
-    def scope(scoped: Scoped) = {
-      val scope0 = scoped.scope
-      if (scope0.project == This) scope0 in proj
-      else scope0
-    }
-
-    def ident(scoped: Scoped) : String = {
-      val scope = scoped.scope
-      (scope.config.toOption match {
-        case None => ""
-        case Some(ConfigKey("compile")) => ""
-        case Some(ConfigKey(x)) => x + "_"
-      }) +
-      (scope.task.toOption match {
-        case None => ""
-        case Some(x) => x.label + "_"
-      }) +
-      (scoped.key.label.split("-").toList match {
-        case Nil => ""
-        case x :: xs => x + (xs map {_.capitalize}).mkString("")
-      })
-    }
   }
+
 }

--- a/src/main/scala/sbtbuildinfo/BuildInfoPlugin.scala
+++ b/src/main/scala/sbtbuildinfo/BuildInfoPlugin.scala
@@ -18,6 +18,9 @@ object BuildInfoPlugin extends sbt.AutoPlugin {
     val BuildInfoType = sbtbuildinfo.BuildInfoType
     type BuildInfoType = sbtbuildinfo.BuildInfoType
     val addBuildInfoToConfig = buildInfoScopedSettings _
+
+    val buildInfoValues: TaskKey[Seq[BuildInfoResult]] =
+      taskKey("BuildInfo keys/values/types for use in the sbt build")
   }
   import autoImport._
 
@@ -54,6 +57,9 @@ object BuildInfoPlugin extends sbt.AutoPlugin {
         state.value,
         streams.value.cacheDirectory
     )),
+    buildInfoValues :=
+      BuildInfo.results(buildInfoKeys.value, buildInfoOptions.value, thisProjectRef.value, state.value),
+
     sourceGenerators ++= {
       if (buildInfoRenderer.value.isSource) Seq(buildInfo.taskValue) else Nil
     },


### PR DESCRIPTION
Adds `buildInfoValues` task, which exposes the set of `BuildInfoResult` objects used by sbt-buildinfo to generate BuildInfo files. 
This can be used within the sbt build itself to add the build info to the jar Manifest.
