### PR TITLE
Updated repos for ls-sbt plugin.

### DIFF
--- a/project/ls.sbt
+++ b/project/ls.sbt
@@ -1,5 +1,6 @@
 resolvers ++= Seq(
-  "less is" at "http://repo.lessis.me",
-  "coda" at "http://repo.codahale.com")
+  Classpaths.sbtPluginReleases,
+  Opts.resolver.sonatypeReleases
+)
 
 addSbtPlugin("me.lessis" % "ls-sbt" % "0.1.3")


### PR DESCRIPTION
The old repos seem to be offline; these changes are the recommendations from the [ls-sbt repo](https://github.com/softprops/ls).
