### PR TITLE
Make `toJson` more JSONish

### DIFF
--- a/src/main/scala/sbtbuildinfo/ScalaCaseObjectRenderer.scala
+++ b/src/main/scala/sbtbuildinfo/ScalaCaseObjectRenderer.scala
@@ -62,7 +62,17 @@ private[sbtbuildinfo] case class ScalaCaseObjectRenderer(options: Seq[BuildInfoO
 
   def toJsonLine: Seq[String] =
     if (options contains BuildInfoOption.ToJson)
-      List("""  val toJson: String = toMap.map(i => "\"" + i._1 + "\":\"" + i._2 + "\"").mkString("{", ", ", "}")""")
+      List(
+         """  val toJson: String = toMap.map{ i =>
+           |    def quote(x:Any) : String = "\"" + x + "\""
+           |    val key : String = quote(i._1)
+           |    val value : String = i._2 match {
+           |       case elem : Seq[_] => elem.map(quote).mkString("[", ",", "]")
+           |       case elem : Option[_] => elem.map(quote).getOrElse("null")
+           |       case elem => quote(elem)
+           |    }
+           |    s"$key : $value"
+           |    }.mkString("{", ", ", "}")""".stripMargin)
     else Nil
 
 }

--- a/src/sbt-test/sbt-buildinfo/options/build.sbt
+++ b/src/sbt-test/sbt-buildinfo/options/build.sbt
@@ -40,8 +40,17 @@ lazy val root = (project in file(".")).
              """  val toMap: Map[String, Any] = Map[String, Any](""" ::
              """    "name" -> name,""" ::
              """    "scalaVersion" -> scalaVersion)""" ::
-             "" ::
-             """  val toJson: String = toMap.map(i => "\"" + i._1 + "\":\"" + i._2 + "\"").mkString("{", ", ", "}")""" ::
+             """""" ::
+             """  val toJson: String = toMap.map{ i =>""" ::
+             """    def quote(x:Any) : String = "\"" + x + "\""""" ::
+             """    val key : String = quote(i._1)""" ::
+             """    val value : String = i._2 match {""" ::
+             """       case elem : Seq[_] => elem.map(quote).mkString("[", ",", "]")""" ::
+             """       case elem : Option[_] => elem.map(quote).getOrElse("null")""" ::
+             """       case elem => quote(elem)""" ::
+             """    }""" ::
+             """    s"$key : $value"""" ::
+             """    }.mkString("{", ", ", "}")""" ::
              """}""" :: Nil =>
         case _ => sys.error("unexpected output: \n" + lines.mkString("\n"))
       }


### PR DESCRIPTION
In all HTTP services I make, I add an endpoint `/build` outputting the `toJson` result of the BuildInfo. That output is not fully JSON and thus I lack the ability of manipulating output. This pull request is for making that output a bit more JSONish without going full way about adding an external dependency like `akka-http-spray-json`.

Now I'm able to compare libraries compiled in two instances by doing things like:

`curl localhost:8900/build | jq ".libraryDependencies | sort"`