### PR TITLE
Do not generate multi-parameter infix calls

### DIFF
--- a/src/main/scala/sbtbuildinfo/ScalaCaseObjectRenderer.scala
+++ b/src/main/scala/sbtbuildinfo/ScalaCaseObjectRenderer.scala
@@ -45,7 +45,7 @@ private[sbtbuildinfo] case class ScalaCaseObjectRenderer(options: Seq[BuildInfoO
     val fmt = idents.map("%s: %%s" format _).mkString(", ")
     val vars = idents.mkString(", ")
     s"""  override val toString: String = {
-         |    "$fmt" format (
+         |    "$fmt".format(
          |      $vars
          |    )
          |  }""".stripMargin

--- a/src/sbt-test/sbt-buildinfo/append/build.sbt
+++ b/src/sbt-test/sbt-buildinfo/append/build.sbt
@@ -41,7 +41,7 @@ lazy val root = (project in file(".")).
              """  /** The value is scala.collection.Seq("Sonatype Public: https://oss.sonatype.org/content/groups/public"). */""" ::
              """  val resolvers: scala.collection.Seq[String] = scala.collection.Seq("Sonatype Public: https://oss.sonatype.org/content/groups/public")""" ::
              """  override val toString: String = {""" ::
-             """    "name: %s, version: %s, scalaVersion: %s, sbtVersion: %s, organization: %s, libraryDependencies: %s, test_libraryDependencies: %s, resolvers: %s" format (""" ::
+             """    "name: %s, version: %s, scalaVersion: %s, sbtVersion: %s, organization: %s, libraryDependencies: %s, test_libraryDependencies: %s, resolvers: %s".format(""" ::
              """      name, version, scalaVersion, sbtVersion, organization, libraryDependencies, test_libraryDependencies, resolvers""" ::
              """    )""" ::
              """  }""" ::

--- a/src/sbt-test/sbt-buildinfo/buildtime/build.sbt
+++ b/src/sbt-test/sbt-buildinfo/buildtime/build.sbt
@@ -38,7 +38,7 @@ lazy val root = (project in file(".")).
           builtAtMillisComment ::
           builtAtMillis ::
           """  override val toString: String = {""" ::
-          """    "name: %s, version: %s, scalaVersion: %s, builtAtString: %s, builtAtMillis: %s" format (""" ::
+          """    "name: %s, version: %s, scalaVersion: %s, builtAtString: %s, builtAtMillis: %s".format(""" ::
           """      name, version, scalaVersion, builtAtString, builtAtMillis""" ::
           """    )""" ::
           """  }""" ::

--- a/src/sbt-test/sbt-buildinfo/caching/build.sbt
+++ b/src/sbt-test/sbt-buildinfo/caching/build.sbt
@@ -26,7 +26,7 @@ lazy val root = (project in file(".")).
              """  /** The value is "0.1". */""" ::
              """  val version: String = "0.1"""" ::
              """  override val toString: String = {""" ::
-             """    "name: %s, version: %s" format (""" ::
+             """    "name: %s, version: %s".format(""" ::
              """      name, version""" ::
              """    )""" ::
              """  }""" ::

--- a/src/sbt-test/sbt-buildinfo/multi/build.sbt
+++ b/src/sbt-test/sbt-buildinfo/multi/build.sbt
@@ -43,7 +43,7 @@ lazy val app = (project in file("app")).
              """  /** The value is "2.10.2". */""" ::
              """  val scalaVersion: String = "2.10.2"""" ::
              """  override val toString: String = {""" ::
-             """    "name: %s, projectID: %s, version: %s, homepage: %s, scalaVersion: %s" format (""" ::
+             """    "name: %s, projectID: %s, version: %s, homepage: %s, scalaVersion: %s".format(""" ::
              """      name, projectID, version, homepage, scalaVersion""" ::
              """    )""" ::
              """  }""" ::

--- a/src/sbt-test/sbt-buildinfo/options/build.sbt
+++ b/src/sbt-test/sbt-buildinfo/options/build.sbt
@@ -33,7 +33,7 @@ lazy val root = (project in file(".")).
              """  /** The value is "2.10.2". */""" ::
              """  val scalaVersion: String = "2.10.2"""" ::
              """  override val toString: String = {""" ::
-             """    "name: %s, scalaVersion: %s" format (""" ::
+             """    "name: %s, scalaVersion: %s".format(""" ::
              """      name, scalaVersion""" ::
              """    )""" ::
              """  }""" ::

--- a/src/sbt-test/sbt-buildinfo/simple/build.sbt
+++ b/src/sbt-test/sbt-buildinfo/simple/build.sbt
@@ -64,7 +64,7 @@ lazy val root = (project in file(".")).
              targetInfoComment ::
              targetInfo :: // """
              """  override val toString: String = {""" ::
-             """    "name: %s, projectVersion: %s, scalaVersion: %s, ivyXML: %s, homepage: %s, licenses: %s, apiMappings: %s, isSnapshot: %s, year: %s, sym: %s, buildTime: %s, someCp: %s, target: %s" format (""" ::
+             """    "name: %s, projectVersion: %s, scalaVersion: %s, ivyXML: %s, homepage: %s, licenses: %s, apiMappings: %s, isSnapshot: %s, year: %s, sym: %s, buildTime: %s, someCp: %s, target: %s".format(""" ::
              """      name, projectVersion, scalaVersion, ivyXML, homepage, licenses, apiMappings, isSnapshot, year, sym, buildTime, someCp, target""" ::
              """    )""" ::
              """  }""" ::

--- a/src/sbt-test/sbt-buildinfo/usepackageaspath/build.sbt
+++ b/src/sbt-test/sbt-buildinfo/usepackageaspath/build.sbt
@@ -59,7 +59,7 @@ lazy val root = (project in file(".")).
              targetInfoComment ::
              targetInfo :: // """
              """  override val toString: String = {""" ::
-             """    "name: %s, projectVersion: %s, scalaVersion: %s, ivyXML: %s, homepage: %s, licenses: %s, apiMappings: %s, isSnapshot: %s, year: %s, sym: %s, buildTime: %s, target: %s" format (""" ::
+             """    "name: %s, projectVersion: %s, scalaVersion: %s, ivyXML: %s, homepage: %s, licenses: %s, apiMappings: %s, isSnapshot: %s, year: %s, sym: %s, buildTime: %s, target: %s".format(""" ::
              """      name, projectVersion, scalaVersion, ivyXML, homepage, licenses, apiMappings, isSnapshot, year, sym, buildTime, target""" ::
              """    )""" ::
              """  }""" ::


### PR DESCRIPTION
Multi-parameter infix calls may be removed in the future, so it's better
not to generate this kind of code.

This is blocking us for removing autotupling and multi-parameter infix calls in Dotty (see lampepfl/dotty#4311), because we use sbt-buildinfo to generate the config of the language server when testing (the language server is compiled with Dotty).