### PR TITLE
Correct json for nested objects

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.1.1
+sbt.version=1.1.5

--- a/src/main/scala/sbtbuildinfo/ScalaCaseObjectRenderer.scala
+++ b/src/main/scala/sbtbuildinfo/ScalaCaseObjectRenderer.scala
@@ -63,20 +63,26 @@ private[sbtbuildinfo] case class ScalaCaseObjectRenderer(options: Seq[BuildInfoO
   def toJsonLine: Seq[String] =
     if (options contains BuildInfoOption.ToJson)
       List(
-         """  private def quote(x: Any): String = "\"" + x + "\""
-           |
-           |  private def toJsonValue(value: Any): String = {
-           |    value match {
-           |      case elem: Seq[_] => elem.map(toJsonValue).mkString("[", ",", "]")
-           |      case elem: Option[_] => elem.map(toJsonValue).orNull
-           |      case elem: Map[String, Any] => elem.map {
-           |        case (k, v) => toJsonValue(k) + ":" + toJsonValue(v)
-           |      }.mkString("{", ", ", "}")
-           |      case other => quote(other)
-           |    }
-           |  }
-           |
-           |  val toJson: String = toJsonValue(toMap)""".stripMargin)
+         """|  private def quote(x: Any): String = "\"" + x + "\""
+            |  private def toJsonValue(value: Any): String = {
+            |    value match {
+            |      case elem: Seq[_] => elem.map(toJsonValue).mkString("[", ",", "]")
+            |      case elem: Option[_] => elem.map(toJsonValue).getOrElse("null")
+            |      case elem: Map[String, Any] => elem.map {
+            |        case (k, v) => toJsonValue(k) + ":" + toJsonValue(v)
+            |      }.mkString("{", ", ", "}")
+            |      case d: Double => d.toString
+            |      case f: Float => f.toString
+            |      case l: Long => l.toString
+            |      case i: Int => i.toString
+            |      case s: Short => s.toString
+            |      case bool: Boolean => bool.toString
+            |      case str: String => quote(str)
+            |      case other => quote(other.toString)
+            |    }
+            |  }
+            |
+            |  val toJson: String = toJsonValue(toMap)""".stripMargin)
     else Nil
 
 }

--- a/src/main/scala/sbtbuildinfo/ScalaCaseObjectRenderer.scala
+++ b/src/main/scala/sbtbuildinfo/ScalaCaseObjectRenderer.scala
@@ -70,7 +70,7 @@ private[sbtbuildinfo] case class ScalaCaseObjectRenderer(options: Seq[BuildInfoO
            |      case elem: Seq[_] => elem.map(toJsonValue).mkString("[", ",", "]")
            |      case elem: Option[_] => elem.map(toJsonValue).orNull
            |      case elem: Map[String, Any] => elem.map {
-           |        case (k, v) => quote(k) + ":" + toJsonValue(v)
+           |        case (k, v) => toJsonValue(k) + ":" + toJsonValue(v)
            |      }.mkString("{", ", ", "}")
            |      case other => quote(other)
            |    }

--- a/src/sbt-test/sbt-buildinfo/options/build.sbt
+++ b/src/sbt-test/sbt-buildinfo/options/build.sbt
@@ -41,16 +41,20 @@ lazy val root = (project in file(".")).
              """    "name" -> name,""" ::
              """    "scalaVersion" -> scalaVersion)""" ::
              """""" ::
-             """  val toJson: String = toMap.map{ i =>""" ::
-             """    def quote(x:Any) : String = "\"" + x + "\""""" ::
-             """    val key : String = quote(i._1)""" ::
-             """    val value : String = i._2 match {""" ::
-             """       case elem : Seq[_] => elem.map(quote).mkString("[", ",", "]")""" ::
-             """       case elem : Option[_] => elem.map(quote).getOrElse("null")""" ::
-             """       case elem => quote(elem)""" ::
+             """  private def quote(x: Any): String = "\"" + x + "\""""" ::
+             """""" ::
+             """  private def toJsonValue(value: Any): String = {""" ::
+             """    value match {""" ::
+             """      case elem : Seq[_] => elem.map(toJsonValue).mkString("[", ",", "]")""" ::
+             """      case elem : Option[_] => elem.map(toJsonValue).orNull""" ::
+             """      case elem: Map[String, Any] => elem.map {""" ::
+             """        case (k, v) => quote(k) + ":" + toJsonValue(v)""" ::
+             """      }.mkString("{", ", ", "}")""" ::
+             """      case other => quote(other)""" ::
              """    }""" ::
-             """    s"$key : $value"""" ::
-             """    }.mkString("{", ", ", "}")""" ::
+             """  }""" ::
+             """""" ::
+             """  val toJson: String = toJsonValue(toMap)""" ::
              """}""" :: Nil =>
         case _ => sys.error("unexpected output: \n" + lines.mkString("\n"))
       }

--- a/src/sbt-test/sbt-buildinfo/options/build.sbt
+++ b/src/sbt-test/sbt-buildinfo/options/build.sbt
@@ -42,15 +42,21 @@ lazy val root = (project in file(".")).
              """    "scalaVersion" -> scalaVersion)""" ::
              """""" ::
              """  private def quote(x: Any): String = "\"" + x + "\""""" ::
-             """""" ::
              """  private def toJsonValue(value: Any): String = {""" ::
              """    value match {""" ::
-             """      case elem : Seq[_] => elem.map(toJsonValue).mkString("[", ",", "]")""" ::
-             """      case elem : Option[_] => elem.map(toJsonValue).orNull""" ::
+             """      case elem: Seq[_] => elem.map(toJsonValue).mkString("[", ",", "]")""" ::
+             """      case elem: Option[_] => elem.map(toJsonValue).getOrElse("null")""" ::
              """      case elem: Map[String, Any] => elem.map {""" ::
              """        case (k, v) => toJsonValue(k) + ":" + toJsonValue(v)""" ::
              """      }.mkString("{", ", ", "}")""" ::
-             """      case other => quote(other)""" ::
+             """      case d: Double => d.toString""" ::
+             """      case f: Float => f.toString""" ::
+             """      case l: Long => l.toString""" ::
+             """      case i: Int => i.toString""" ::
+             """      case s: Short => s.toString""" ::
+             """      case bool: Boolean => bool.toString""" ::
+             """      case str: String => quote(str)""" ::
+             """      case other => quote(other.toString)""" ::
              """    }""" ::
              """  }""" ::
              """""" ::

--- a/src/sbt-test/sbt-buildinfo/options/build.sbt
+++ b/src/sbt-test/sbt-buildinfo/options/build.sbt
@@ -48,7 +48,7 @@ lazy val root = (project in file(".")).
              """      case elem : Seq[_] => elem.map(toJsonValue).mkString("[", ",", "]")""" ::
              """      case elem : Option[_] => elem.map(toJsonValue).orNull""" ::
              """      case elem: Map[String, Any] => elem.map {""" ::
-             """        case (k, v) => quote(k) + ":" + toJsonValue(v)""" ::
+             """        case (k, v) => toJsonValue(k) + ":" + toJsonValue(v)""" ::
              """      }.mkString("{", ", ", "}")""" ::
              """      case other => quote(other)""" ::
              """    }""" ::


### PR DESCRIPTION
Now if have the next keys
```scala
buildInfoKeys := Seq[BuildInfoKey.Entry[_]](
  "build_number" -> version.value,
  "git" -> Map(
    "commit" -> git.gitHeadCommit.value,
    "commit_date" -> git.gitHeadCommitDate.value,
    "tags" -> git.gitCurrentTags.value,
    "commit_branch" -> git.gitCurrentBranch.value
  )
)
```
we will get the next json:
```json
{"build_number" : "1.0-SNAPSHOT", "git" : "Map(commit -> Some(67858ae976394cfd6dfe27336905458a8412d383), commit_date -> Some(2018-05-15T15:48:43+0300), tags -> List(), commit_branch -> develop-commons)"}
```
So we have wrong representation for nested Map object.
This merge request allow to generate more correctly json for nested objects.