### PR TITLE
delete build.properties in test. re-enable "append" test

### DIFF
--- a/src/sbt-test/sbt-buildinfo/append/build.sbt
+++ b/src/sbt-test/sbt-buildinfo/append/build.sbt
@@ -30,8 +30,8 @@ lazy val root = (project in file(".")).
              """  val version: String = "0.1"""" ::
              """  /** The value is "2.10.2". */""" ::
              """  val scalaVersion: String = "2.10.2"""" ::
-             """  /** The value is "0.13.11". */""" ::
-             """  val sbtVersion: String = "0.13.11"""" ::
+             """  /** The value is "1.1.6". */""" ::
+             """  val sbtVersion: String = "1.1.6"""" ::
              """  /** The value is "com.eed3si9n". */""" ::
              """  val organization: String = "com.eed3si9n"""" ::
              """  /** The value is scala.collection.Seq("org.scala-lang:scala-library:2.10.2"). */""" ::

--- a/src/sbt-test/sbt-buildinfo/append/project/build.properties
+++ b/src/sbt-test/sbt-buildinfo/append/project/build.properties
@@ -1,1 +1,0 @@
-sbt.version=0.13.11


### PR DESCRIPTION
sbt-buildinfo already dropped sbt 0.13.x support. `sbt-test/sbt-buildinfo/append` ignored due to https://github.com/sbt/sbt/pull/3566