### PR TITLE
Remove warning about out-of-graph task execution

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -90,15 +90,6 @@ This generates:
 
 Tasks can be added only if they do not depend on `sourceGenerators`. Otherwise, it will cause an infinite loop.
 
-**CAVEAT**: The tasks added to `buildInfoKeys` are not deduplicated against sbt's task engine.  Therefore,
-calling complex tasks that require locking and/or exclusive access may cause unexpected race condition.  Keep it
-to relatively simple tasks.  See [#87][] / [scala-js/scala-js#2363][] / [sbt/sbt#2970][] / [sbt/sbt#2156][].
-
-[#87]: https://github.com/sbt/sbt-buildinfo/issues/87
-[scala-js/scala-js#2363]: https://github.com/scala-js/scala-js/issues/2363
-[sbt/sbt#2970]: https://github.com/sbt/sbt/issues/2970
-[sbt/sbt#2156]: https://github.com/sbt/sbt/issues/2156
-
 Here's how to change the generated object name:
 
 ```scala


### PR DESCRIPTION
As far as I can see & understand, this has been fixed in the 0.8.0/0.9.0 release by @dwijnand , so the warning should no longer be necessary.