### PR TITLE
Switch from generating scala.collection.Seq to scala.Seq

### DIFF
--- a/src/main/scala/sbtbuildinfo/ScalaRenderer.scala
+++ b/src/main/scala/sbtbuildinfo/ScalaRenderer.scala
@@ -27,8 +27,8 @@ abstract class ScalaRenderer extends BuildInfoRenderer {
 
         case TypeExpression("scala.Option", Seq(arg)) =>
           tpeToReturnType(arg) map { x => s"scala.Option[$x]" }
-        case TypeExpression("scala.collection.Seq", Seq(arg)) =>
-          tpeToReturnType(arg) map { x => s"scala.collection.Seq[$x]" }
+        case TypeExpression("scala.collection.Seq" | "scala.collection.immutable.Seq", Seq(arg)) =>
+          tpeToReturnType(arg) map { x => s"scala.collection.immutable.Seq[$x]" }
         case TypeExpression("scala.collection.immutable.Map", Seq(arg0, arg1)) =>
           for {
             x0 <- tpeToReturnType(arg0)
@@ -50,7 +50,7 @@ abstract class ScalaRenderer extends BuildInfoRenderer {
     case node: scala.xml.NodeSeq if node.toString().trim.nonEmpty => node.toString()
     case (k, _v)            => "(%s -> %s)" format(quote(k), quote(_v))
     case mp: Map[_, _]      => mp.toList.map(quote(_)).mkString("Map(", ", ", ")")
-    case seq: Seq[_]        => seq.map(quote).mkString("scala.collection.Seq(", ", ", ")")
+    case seq: collection.Seq[_] => seq.map(quote).mkString("scala.collection.immutable.Seq(", ", ", ")")
     case op: Option[_]      => op map { x => "scala.Some(" + quote(x) + ")" } getOrElse {"scala.None"}
     case url: java.net.URL  => "new java.net.URL(%s)" format quote(url.toString)
     case file: java.io.File => "new java.io.File(%s)" format quote(file.toString)

--- a/src/main/scala/sbtbuildinfo/package.scala
+++ b/src/main/scala/sbtbuildinfo/package.scala
@@ -77,7 +77,7 @@ package object sbtbuildinfo {
     }
 
     @deprecated("No longer used", "0.9.0")
-    def ofNImpl(xs: Tree*): Tree = q"_root_.scala.Seq(..${xs map ofImpl})"
+    def ofNImpl(xs: Tree*): Tree = q"_root_.scala.collection.immutable.Seq(..${xs map ofImpl})"
 
   }
 }

--- a/src/sbt-test/sbt-buildinfo/append/build.sbt
+++ b/src/sbt-test/sbt-buildinfo/append/build.sbt
@@ -34,12 +34,12 @@ lazy val root = (project in file(".")).
              """  val sbtVersion: String = "1.2.8"""" ::
              """  /** The value is "com.eed3si9n". */""" ::
              """  val organization: String = "com.eed3si9n"""" ::
-             """  /** The value is scala.collection.Seq("org.scala-lang:scala-library:2.12.7", "org.scala-sbt:scripted-sbt:1.2.8:scripted-sbt", "org.scala-sbt:sbt-launch:1.2.8:scripted-sbt-launch"). */""" ::
-             """  val libraryDependencies: scala.collection.Seq[String] = scala.collection.Seq("org.scala-lang:scala-library:2.12.7", "org.scala-sbt:scripted-sbt:1.2.8:scripted-sbt", "org.scala-sbt:sbt-launch:1.2.8:scripted-sbt-launch")""" ::
-             """  /** The value is scala.collection.Seq("org.scala-lang:scala-library:2.12.7", "org.scala-sbt:scripted-sbt:1.2.8:scripted-sbt", "org.scala-sbt:sbt-launch:1.2.8:scripted-sbt-launch"). */""" ::
-             """  val test_libraryDependencies: scala.collection.Seq[String] = scala.collection.Seq("org.scala-lang:scala-library:2.12.7", "org.scala-sbt:scripted-sbt:1.2.8:scripted-sbt", "org.scala-sbt:sbt-launch:1.2.8:scripted-sbt-launch")""" ::
-             """  /** The value is scala.collection.Seq("Sonatype Public: https://oss.sonatype.org/content/groups/public"). */""" ::
-             """  val resolvers: scala.collection.Seq[String] = scala.collection.Seq("Sonatype Public: https://oss.sonatype.org/content/groups/public")""" ::
+             """  /** The value is scala.collection.immutable.Seq("org.scala-lang:scala-library:2.12.7", "org.scala-sbt:scripted-sbt:1.2.8:scripted-sbt", "org.scala-sbt:sbt-launch:1.2.8:scripted-sbt-launch"). */""" ::
+             """  val libraryDependencies: scala.collection.immutable.Seq[String] = scala.collection.immutable.Seq("org.scala-lang:scala-library:2.12.7", "org.scala-sbt:scripted-sbt:1.2.8:scripted-sbt", "org.scala-sbt:sbt-launch:1.2.8:scripted-sbt-launch")""" ::
+             """  /** The value is scala.collection.immutable.Seq("org.scala-lang:scala-library:2.12.7", "org.scala-sbt:scripted-sbt:1.2.8:scripted-sbt", "org.scala-sbt:sbt-launch:1.2.8:scripted-sbt-launch"). */""" ::
+             """  val test_libraryDependencies: scala.collection.immutable.Seq[String] = scala.collection.immutable.Seq("org.scala-lang:scala-library:2.12.7", "org.scala-sbt:scripted-sbt:1.2.8:scripted-sbt", "org.scala-sbt:sbt-launch:1.2.8:scripted-sbt-launch")""" ::
+             """  /** The value is scala.collection.immutable.Seq("Sonatype Public: https://oss.sonatype.org/content/groups/public"). */""" ::
+             """  val resolvers: scala.collection.immutable.Seq[String] = scala.collection.immutable.Seq("Sonatype Public: https://oss.sonatype.org/content/groups/public")""" ::
              """  override val toString: String = {""" ::
              """    "name: %s, version: %s, scalaVersion: %s, sbtVersion: %s, organization: %s, libraryDependencies: %s, test_libraryDependencies: %s, resolvers: %s".format(""" ::
              """      name, version, scalaVersion, sbtVersion, organization, libraryDependencies, test_libraryDependencies, resolvers""" ::

--- a/src/sbt-test/sbt-buildinfo/caseclassrenderer/build.sbt
+++ b/src/sbt-test/sbt-buildinfo/caseclassrenderer/build.sbt
@@ -44,7 +44,7 @@ lazy val root = (project in file(".")).
           """  scalaVersion: String,""" ::
           """  ivyXML: scala.xml.NodeSeq,""" ::
           """  homepage: scala.Option[java.net.URL],""" ::
-          """  licenses: scala.collection.Seq[(String, java.net.URL)],""" ::
+          """  licenses: scala.collection.immutable.Seq[(String, java.net.URL)],""" ::
           """  apiMappings: Map[java.io.File, java.net.URL],""" ::
           """  isSnapshot: scala.Boolean,""" ::
           """  year: scala.Int,""" ::
@@ -60,9 +60,9 @@ lazy val root = (project in file(".")).
           """    name = "helloworld",""" ::
           """    projectVersion = 0.1,""" ::
           """    scalaVersion = "2.11.12",""" ::
-          """    ivyXML = scala.collection.Seq(),""" ::
+          """    ivyXML = scala.collection.immutable.Seq(),""" ::
           """    homepage = scala.Some(new java.net.URL("http://example.com")),""" ::
-          """    licenses = scala.collection.Seq(("MIT License" -> new java.net.URL("https://github.com/sbt/sbt-buildinfo/blob/master/LICENSE"))),""" ::
+          """    licenses = scala.collection.immutable.Seq(("MIT License" -> new java.net.URL("https://github.com/sbt/sbt-buildinfo/blob/master/LICENSE"))),""" ::
           """    apiMappings = Map(),""" ::
           """    isSnapshot = false,""" ::
           """    year = 2012,""" ::

--- a/src/sbt-test/sbt-buildinfo/finalcaseobjectrenderer/build.sbt
+++ b/src/sbt-test/sbt-buildinfo/finalcaseobjectrenderer/build.sbt
@@ -46,12 +46,12 @@ lazy val root = (project in file(".")).
           """  final val projectVersion = 0.1""" ::
           """  /** The value is "2.12.7". */""" ::
           """  final val scalaVersion: String = "2.12.7"""" ::
-          """  /** The value is scala.collection.Seq(). */""" ::
-          """  final val ivyXML: scala.xml.NodeSeq = scala.collection.Seq()""" ::
+          """  /** The value is scala.collection.immutable.Seq(). */""" ::
+          """  final val ivyXML: scala.xml.NodeSeq = scala.collection.immutable.Seq()""" ::
           """  /** The value is scala.Some(new java.net.URL("http://example.com")). */""" ::
           """  final val homepage: scala.Option[java.net.URL] = scala.Some(new java.net.URL("http://example.com"))""" ::
-          """  /** The value is scala.collection.Seq(("MIT License" -> new java.net.URL("https://github.com/sbt/sbt-buildinfo/blob/master/LICENSE"))). */""" ::
-          """  final val licenses: scala.collection.Seq[(String, java.net.URL)] = scala.collection.Seq(("MIT License" -> new java.net.URL("https://github.com/sbt/sbt-buildinfo/blob/master/LICENSE")))""" ::
+          """  /** The value is scala.collection.immutable.Seq(("MIT License" -> new java.net.URL("https://github.com/sbt/sbt-buildinfo/blob/master/LICENSE"))). */""" ::
+          """  final val licenses: scala.collection.immutable.Seq[(String, java.net.URL)] = scala.collection.immutable.Seq(("MIT License" -> new java.net.URL("https://github.com/sbt/sbt-buildinfo/blob/master/LICENSE")))""" ::
           """  /** The value is Map(). */""" ::
           """  final val apiMappings: Map[java.io.File, java.net.URL] = Map()""" ::
           """  /** The value is false. */""" ::
@@ -62,8 +62,8 @@ lazy val root = (project in file(".")).
           """  final val sym: scala.Symbol = 'Foo""" ::
           """  /** The value is 1234L. */""" ::
           """  final val buildTime: scala.Long = 1234L""" ::
-          """  /** The value is scala.collection.Seq(new java.io.File("/tmp/f.txt")). */""" ::
-          """  final val someCp: scala.collection.Seq[java.io.File] = scala.collection.Seq(new java.io.File("/tmp/f.txt"))""" ::
+          """  /** The value is scala.collection.immutable.Seq(new java.io.File("/tmp/f.txt")). */""" ::
+          """  final val someCp: scala.collection.immutable.Seq[java.io.File] = scala.collection.immutable.Seq(new java.io.File("/tmp/f.txt"))""" ::
           targetInfoComment ::
           targetInfo :: // """
           """  override val toString: String = {""" ::

--- a/src/sbt-test/sbt-buildinfo/simple/build.sbt
+++ b/src/sbt-test/sbt-buildinfo/simple/build.sbt
@@ -43,12 +43,12 @@ lazy val root = (project in file(".")).
              """  val projectVersion = 0.1""" ::
              """  /** The value is "2.12.7". */""" ::
              """  val scalaVersion: String = "2.12.7"""" ::
-             """  /** The value is scala.collection.Seq(). */""" ::
-             """  val ivyXML: scala.xml.NodeSeq = scala.collection.Seq()""" ::
+             """  /** The value is scala.collection.immutable.Seq(). */""" ::
+             """  val ivyXML: scala.xml.NodeSeq = scala.collection.immutable.Seq()""" ::
              """  /** The value is scala.Some(new java.net.URL("http://example.com")). */""" ::
              """  val homepage: scala.Option[java.net.URL] = scala.Some(new java.net.URL("http://example.com"))""" ::
-             """  /** The value is scala.collection.Seq(("MIT License" -> new java.net.URL("https://github.com/sbt/sbt-buildinfo/blob/master/LICENSE"))). */""" ::
-             """  val licenses: scala.collection.Seq[(String, java.net.URL)] = scala.collection.Seq(("MIT License" -> new java.net.URL("https://github.com/sbt/sbt-buildinfo/blob/master/LICENSE")))""" ::
+             """  /** The value is scala.collection.immutable.Seq(("MIT License" -> new java.net.URL("https://github.com/sbt/sbt-buildinfo/blob/master/LICENSE"))). */""" ::
+             """  val licenses: scala.collection.immutable.Seq[(String, java.net.URL)] = scala.collection.immutable.Seq(("MIT License" -> new java.net.URL("https://github.com/sbt/sbt-buildinfo/blob/master/LICENSE")))""" ::
              """  /** The value is Map(). */""" ::
              """  val apiMappings: Map[java.io.File, java.net.URL] = Map()""" ::
              """  /** The value is false. */""" ::
@@ -59,8 +59,8 @@ lazy val root = (project in file(".")).
              """  val sym: scala.Symbol = 'Foo""" ::
              """  /** The value is 1234L. */""" ::
              """  val buildTime: scala.Long = 1234L""" ::
-             """  /** The value is scala.collection.Seq(new java.io.File("/tmp/f.txt")). */""" ::
-             """  val someCp: scala.collection.Seq[java.io.File] = scala.collection.Seq(new java.io.File("/tmp/f.txt"))""" ::
+             """  /** The value is scala.collection.immutable.Seq(new java.io.File("/tmp/f.txt")). */""" ::
+             """  val someCp: scala.collection.immutable.Seq[java.io.File] = scala.collection.immutable.Seq(new java.io.File("/tmp/f.txt"))""" ::
              targetInfoComment ::
              targetInfo :: // """
              """  override val toString: String = {""" ::

--- a/src/sbt-test/sbt-buildinfo/usepackageaspath/build.sbt
+++ b/src/sbt-test/sbt-buildinfo/usepackageaspath/build.sbt
@@ -41,12 +41,12 @@ lazy val root = (project in file(".")).
              """  val projectVersion = 0.1""" ::
              """  /** The value is "2.12.7". */""" ::
              """  val scalaVersion: String = "2.12.7"""" ::
-             """  /** The value is scala.collection.Seq(). */""" ::
-             """  val ivyXML: scala.xml.NodeSeq = scala.collection.Seq()""" ::
+             """  /** The value is scala.collection.immutable.Seq(). */""" ::
+             """  val ivyXML: scala.xml.NodeSeq = scala.collection.immutable.Seq()""" ::
              """  /** The value is scala.Some(new java.net.URL("http://example.com")). */""" ::
              """  val homepage: scala.Option[java.net.URL] = scala.Some(new java.net.URL("http://example.com"))""" ::
-             """  /** The value is scala.collection.Seq(("MIT License" -> new java.net.URL("https://github.com/sbt/sbt-buildinfo/blob/master/LICENSE"))). */""" ::
-             """  val licenses: scala.collection.Seq[(String, java.net.URL)] = scala.collection.Seq(("MIT License" -> new java.net.URL("https://github.com/sbt/sbt-buildinfo/blob/master/LICENSE")))""" ::
+             """  /** The value is scala.collection.immutable.Seq(("MIT License" -> new java.net.URL("https://github.com/sbt/sbt-buildinfo/blob/master/LICENSE"))). */""" ::
+             """  val licenses: scala.collection.immutable.Seq[(String, java.net.URL)] = scala.collection.immutable.Seq(("MIT License" -> new java.net.URL("https://github.com/sbt/sbt-buildinfo/blob/master/LICENSE")))""" ::
              """  /** The value is Map(). */""" ::
              """  val apiMappings: Map[java.io.File, java.net.URL] = Map()""" ::
              """  /** The value is false. */""" ::


### PR DESCRIPTION
No effect on 2.12, but on 2.13 this is what should be preferred and
makes the most sense since we're dealing with immutable values.