### PR TITLE
Set homepage setting to GitHub repo

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -15,6 +15,7 @@ lazy val root = (project in file(".")).
     scalacOptions += "-language:experimental.macros",
     libraryDependencies += "org.scala-lang" % "scala-reflect" % scalaVersion.value % Provided,
     description := "sbt plugin to generate build info",
+    homepage := Some(url("https://github.com/sbt/sbt-buildinfo")),
     licenses := Seq("MIT License" -> url("https://github.com/sbt/sbt-buildinfo/blob/master/LICENSE")),
     scriptedLaunchOpts ++= Seq("-Xmx1024M", "-Dplugin.version=" + version.value),
     scriptedBufferLog := false


### PR DESCRIPTION
This enables Scala Steward to link to sbt-buildinfo's homepage, version diff, and release notes, see https://twitter.com/fst9000/status/1194716047376560129.