### PR TITLE
Use local timezone strings for buildAtString

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -159,8 +159,8 @@ buildInfoOptions += BuildInfoOption.BuildTime
 to add timestamp values:
 
 ```scala
-/** The value is "2015-07-30 03:30:16.849". */
-val builtAtString: String = "2015-07-30 03:30:16.849"
+/** The value is "2015-07-30 03:30:16.849-0700". */
+val builtAtString: String = "2015-07-30 03:30:16.849-0700"
 /** The value is 1438227016849L. */
 val builtAtMillis: Long = 1438227016849L
 ```

--- a/src/main/scala/sbtbuildinfo/BuildInfo.scala
+++ b/src/main/scala/sbtbuildinfo/BuildInfo.scala
@@ -13,8 +13,8 @@ object BuildInfo {
   private def extraKeys(options: Seq[BuildInfoOption]): Seq[BuildInfoKey] =
       if (options contains BuildInfoOption.BuildTime) {
         val now = System.currentTimeMillis()
-        val dtf = new java.text.SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS")
-        dtf.setTimeZone(java.util.TimeZone.getTimeZone("UTC"))
+        // Output the build time with the local timezone suffix
+        val dtf = new java.text.SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSSZ")
         val nowStr = dtf.format(new java.util.Date(now))
         Seq[BuildInfoKey](
           "builtAtString" -> nowStr,


### PR DESCRIPTION
- `buildAtString` needs to clarify the timezone by adding `Z` to the date formatter. Having timezone information is generally a good practice to avoid confusion. 
- I chose the local time zone string instead of UTC so that we don't need to translate UTC timezone into our local time zone in our head.
- If we need to have UTC representation, buildAtMillis (since 1970-01-01 UTC) still can be used to generate UTC datetime strings.