### PR TITLE
Replace java.util.Date with java.time.Instant

### DIFF
--- a/src/main/scala/sbtbuildinfo/BuildInfo.scala
+++ b/src/main/scala/sbtbuildinfo/BuildInfo.scala
@@ -12,10 +12,10 @@ object BuildInfo {
 
   private def extraKeys(options: Seq[BuildInfoOption]): Seq[BuildInfoKey] =
       if (options contains BuildInfoOption.BuildTime) {
-        val now = System.currentTimeMillis()
+        val now = java.time.Instant.now().toEpochMilli
         // Output the build time with the local timezone suffix
         val dtf = new java.text.SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSSZ")
-        val nowStr = dtf.format(new java.util.Date(now))
+        val nowStr = dtf.format(now)
         Seq[BuildInfoKey](
           "builtAtString" -> nowStr,
           "builtAtMillis" -> now


### PR DESCRIPTION
Following on from #156, moves to the JSR-310 `java.time.Instant` from `java.util.Date`.  

This is more hygiene/modeling good behavior in not using an API widely considered to be deficient.