### PR TITLE
Test using both Scala 2.13 and 2.12 with -Xfatal-warnings

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,7 @@ lazy val root = (project in file("."))
   .settings(
     name := "sbt-buildinfo",
     pluginCrossBuild / sbtVersion := "1.2.8",
-    scalacOptions := Seq("-Xfuture", "-unchecked", "-deprecation", "-feature", "-language:implicitConversions"),
+    scalacOptions := Seq("-Xlint", "-Xfatal-warnings", "-unchecked", "-deprecation", "-feature", "-language:implicitConversions"),
     scalacOptions += "-language:experimental.macros",
     libraryDependencies += "org.scala-lang" % "scala-reflect" % scalaVersion.value % Provided,
     description := "sbt plugin to generate build info",

--- a/src/main/scala/sbtbuildinfo/BuildInfoKeyMacros.scala
+++ b/src/main/scala/sbtbuildinfo/BuildInfoKeyMacros.scala
@@ -1,0 +1,14 @@
+package sbtbuildinfo
+
+import scala.reflect.macros.blackbox
+
+final class BuildInfoKeyMacros(val c: blackbox.Context) {
+  import c.universe._
+
+  val BuildInfoKey = q"_root_.sbtbuildinfo.BuildInfoKey"
+
+  def taskImpl(key: Tree): Tree = {
+    val A = key.tpe.typeArgs.head
+    q"$BuildInfoKey.sbtbuildinfoTaskValueEntry[$A]($key.taskValue)($key.key.manifest.typeArguments.head.asInstanceOf[_root_.scala.reflect.Manifest[$A]])"
+  }
+}

--- a/src/main/scala/sbtbuildinfo/BuildInfoOption.scala
+++ b/src/main/scala/sbtbuildinfo/BuildInfoOption.scala
@@ -1,7 +1,5 @@
 package sbtbuildinfo
 
-import sbt._
-
 sealed trait BuildInfoOption
 
 object BuildInfoOption {

--- a/src/main/scala/sbtbuildinfo/ScalaCaseObjectRenderer.scala
+++ b/src/main/scala/sbtbuildinfo/ScalaCaseObjectRenderer.scala
@@ -69,8 +69,8 @@ private[sbtbuildinfo] case class ScalaCaseObjectRenderer(options: Seq[BuildInfoO
             |    value match {
             |      case elem: Seq[_] => elem.map(toJsonValue).mkString("[", ",", "]")
             |      case elem: Option[_] => elem.map(toJsonValue).getOrElse("null")
-            |      case elem: Map[String, Any] => elem.map {
-            |        case (k, v) => toJsonValue(k) + ":" + toJsonValue(v)
+            |      case elem: Map[_, Any] => elem.map {
+            |        case (k, v) => toJsonValue(k.toString) + ":" + toJsonValue(v)
             |      }.mkString("{", ", ", "}")
             |      case d: Double => d.toString
             |      case f: Float => f.toString

--- a/src/main/scala/sbtbuildinfo/ScalaFinalCaseObjectRenderer.scala
+++ b/src/main/scala/sbtbuildinfo/ScalaFinalCaseObjectRenderer.scala
@@ -69,8 +69,8 @@ case class ScalaFinalCaseObjectRenderer(options: Seq[BuildInfoOption], pkg: Stri
             |    value match {
             |      case elem: Seq[_] => elem.map(toJsonValue).mkString("[", ",", "]")
             |      case elem: Option[_] => elem.map(toJsonValue).getOrElse("null")
-            |      case elem: Map[String, Any] => elem.map {
-            |        case (k, v) => toJsonValue(k) + ":" + toJsonValue(v)
+            |      case elem: Map[_, Any] => elem.map {
+            |        case (k, v) => toJsonValue(k.toString) + ":" + toJsonValue(v)
             |      }.mkString("{", ", ", "}")
             |      case d: Double => d.toString
             |      case f: Float => f.toString

--- a/src/main/scala/sbtbuildinfo/ScalaRenderer.scala
+++ b/src/main/scala/sbtbuildinfo/ScalaRenderer.scala
@@ -48,7 +48,8 @@ abstract class ScalaRenderer extends BuildInfoRenderer {
   }
 
   protected def quote(v: Any): String = v match {
-    case x @ ( _: Int | _: Double | _: Boolean | _: Symbol) => x.toString
+    case x @ ( _: Int | _: Double | _: Boolean) => x.toString
+    case x: Symbol          => s"""scala.Symbol("${x.name}")"""
     case x: Long            => x.toString + "L"
     case node: scala.xml.NodeSeq if node.toString().trim.nonEmpty => node.toString()
     case (k, _v)            => "(%s -> %s)" format(quote(k), quote(_v))

--- a/src/sbt-test/sbt-buildinfo/append/build.sbt
+++ b/src/sbt-test/sbt-buildinfo/append/build.sbt
@@ -1,24 +1,26 @@
 lazy val check = taskKey[Unit]("check")
 
-lazy val root = (project in file(".")).
-  enablePlugins(BuildInfoPlugin, ScriptedPlugin).
-  settings(
+ThisBuild / scalaVersion := "2.12.12"
+ThisBuild / organization := "com.example"
+ThisBuild / version := "0.1"
+ThisBuild / homepage := Some(url("http://example.com"))
+ThisBuild / licenses := Seq("MIT License" -> url("https://github.com/sbt/sbt-buildinfo/blob/master/LICENSE"))
+
+lazy val root = (project in file("."))
+  .enablePlugins(BuildInfoPlugin, ScriptedPlugin)
+  .settings(
     name := "helloworld",
-    organization := "com.eed3si9n",
-    version := "0.1",
-    scalaVersion := "2.12.7",
+    scalacOptions ++= Seq("-Xlint", "-Xfatal-warnings", "-Yno-imports"),
     buildInfoKeys ++= Seq[BuildInfoKey](name, organization, version, scalaVersion,
       libraryDependencies, libraryDependencies in Test),
     buildInfoKeys += BuildInfoKey(resolvers),
     buildInfoPackage := "hello",
-    homepage := Some(url("http://example.com")),
-    licenses := Seq("MIT License" -> url("https://github.com/sbt/sbt-buildinfo/blob/master/LICENSE")),
     resolvers ++= Seq("Sonatype Public" at "https://oss.sonatype.org/content/groups/public"),
     check := {
       val f = (sourceManaged in Compile).value / "sbt-buildinfo" / ("%s.scala" format "BuildInfo")
       val lines = scala.io.Source.fromFile(f).getLines.toList
       lines match {
-        case """// $COVERAGE-OFF$""" :: 
+        case """// $COVERAGE-OFF$""" ::
              """package hello""" ::
              """""" ::
              """import scala.Predef._""" ::
@@ -29,16 +31,16 @@ lazy val root = (project in file(".")).
              """  val name: String = "helloworld"""" ::
              """  /** The value is "0.1". */""" ::
              """  val version: String = "0.1"""" ::
-             """  /** The value is "2.12.7". */""" ::
-             """  val scalaVersion: String = "2.12.7"""" ::
+             """  /** The value is "2.12.12". */""" ::
+             """  val scalaVersion: String = "2.12.12"""" ::
              """  /** The value is "1.2.8". */""" ::
              """  val sbtVersion: String = "1.2.8"""" ::
-             """  /** The value is "com.eed3si9n". */""" ::
-             """  val organization: String = "com.eed3si9n"""" ::
-             """  /** The value is scala.collection.immutable.Seq("org.scala-lang:scala-library:2.12.7", "org.scala-sbt:scripted-sbt:1.2.8:scripted-sbt", "org.scala-sbt:sbt-launch:1.2.8:scripted-sbt-launch"). */""" ::
-             """  val libraryDependencies: scala.collection.immutable.Seq[String] = scala.collection.immutable.Seq("org.scala-lang:scala-library:2.12.7", "org.scala-sbt:scripted-sbt:1.2.8:scripted-sbt", "org.scala-sbt:sbt-launch:1.2.8:scripted-sbt-launch")""" ::
-             """  /** The value is scala.collection.immutable.Seq("org.scala-lang:scala-library:2.12.7", "org.scala-sbt:scripted-sbt:1.2.8:scripted-sbt", "org.scala-sbt:sbt-launch:1.2.8:scripted-sbt-launch"). */""" ::
-             """  val test_libraryDependencies: scala.collection.immutable.Seq[String] = scala.collection.immutable.Seq("org.scala-lang:scala-library:2.12.7", "org.scala-sbt:scripted-sbt:1.2.8:scripted-sbt", "org.scala-sbt:sbt-launch:1.2.8:scripted-sbt-launch")""" ::
+             """  /** The value is "com.example". */""" ::
+             """  val organization: String = "com.example"""" ::
+             """  /** The value is scala.collection.immutable.Seq("org.scala-lang:scala-library:2.12.12", "org.scala-sbt:scripted-sbt:1.2.8:scripted-sbt", "org.scala-sbt:sbt-launch:1.2.8:scripted-sbt-launch"). */""" ::
+             """  val libraryDependencies: scala.collection.immutable.Seq[String] = scala.collection.immutable.Seq("org.scala-lang:scala-library:2.12.12", "org.scala-sbt:scripted-sbt:1.2.8:scripted-sbt", "org.scala-sbt:sbt-launch:1.2.8:scripted-sbt-launch")""" ::
+             """  /** The value is scala.collection.immutable.Seq("org.scala-lang:scala-library:2.12.12", "org.scala-sbt:scripted-sbt:1.2.8:scripted-sbt", "org.scala-sbt:sbt-launch:1.2.8:scripted-sbt-launch"). */""" ::
+             """  val test_libraryDependencies: scala.collection.immutable.Seq[String] = scala.collection.immutable.Seq("org.scala-lang:scala-library:2.12.12", "org.scala-sbt:scripted-sbt:1.2.8:scripted-sbt", "org.scala-sbt:sbt-launch:1.2.8:scripted-sbt-launch")""" ::
              """  /** The value is scala.collection.immutable.Seq("Sonatype Public: https://oss.sonatype.org/content/groups/public"). */""" ::
              """  val resolvers: scala.collection.immutable.Seq[String] = scala.collection.immutable.Seq("Sonatype Public: https://oss.sonatype.org/content/groups/public")""" ::
              """  override val toString: String = {""" ::
@@ -46,11 +48,10 @@ lazy val root = (project in file(".")).
              """      name, version, scalaVersion, sbtVersion, organization, libraryDependencies, test_libraryDependencies, resolvers""" ::
              """    )""" ::
              """  }""" ::
-             """}""" :: 
+             """}""" ::
              """// $COVERAGE-ON$""" :: Nil =>
         case _ => sys.error("unexpected output: \n" + lines.mkString("\n"))
       }
       ()
     }
   )
-

--- a/src/sbt-test/sbt-buildinfo/buildtime/build.sbt
+++ b/src/sbt-test/sbt-buildinfo/buildtime/build.sbt
@@ -2,12 +2,16 @@ import scala.collection.immutable.::
 
 lazy val check = taskKey[Unit]("checks this plugin")
 
-lazy val root = (project in file(".")).
-  enablePlugins(BuildInfoPlugin).
-  settings(
+ThisBuild / scalaVersion := "2.12.12"
+ThisBuild / organization := "com.example"
+ThisBuild / version := "0.1"
+ThisBuild / homepage := Some(url("http://example.com"))
+ThisBuild / licenses := Seq("MIT License" -> url("https://github.com/sbt/sbt-buildinfo/blob/master/LICENSE"))
+
+lazy val root = (project in file("."))
+  .enablePlugins(BuildInfoPlugin)
+  .settings(
     name := "helloworld",
-    version := "0.1",
-    scalaVersion := "2.12.7",
     buildInfoKeys := Seq(
       name,
       version,
@@ -15,13 +19,12 @@ lazy val root = (project in file(".")).
     ),
     buildInfoPackage := "hello",
     buildInfoOptions := Seq(BuildInfoOption.BuildTime),
-    homepage := Some(url("http://example.com")),
-    licenses := Seq("MIT License" -> url("https://github.com/sbt/sbt-buildinfo/blob/master/LICENSE")),
+    scalacOptions ++= Seq("-Xlint", "-Xfatal-warnings", "-Yno-imports"),
     check := {
       val f = (sourceManaged in Compile).value / "sbt-buildinfo" / ("%s.scala" format "BuildInfo")
       val lines = scala.io.Source.fromFile(f).getLines.toList
       lines match {
-        case """// $COVERAGE-OFF$""" :: 
+        case """// $COVERAGE-OFF$""" ::
           """package hello""" ::
           """""" ::
           """import scala.Predef._""" ::
@@ -32,8 +35,8 @@ lazy val root = (project in file(".")).
           """  val name: String = "helloworld"""" ::
           """  /** The value is "0.1". */"""::
           """  val version: String = "0.1"""" ::
-          """  /** The value is "2.12.7". */""" ::
-          """  val scalaVersion: String = "2.12.7"""" ::
+          """  /** The value is "2.12.12". */""" ::
+          """  val scalaVersion: String = "2.12.12"""" ::
           builtAtStringComment ::
           builtAtString ::
           builtAtMillisComment ::

--- a/src/sbt-test/sbt-buildinfo/caching/build.sbt
+++ b/src/sbt-test/sbt-buildinfo/caching/build.sbt
@@ -1,21 +1,24 @@
 lazy val check = taskKey[Unit]("check")
 
-lazy val root = (project in file(".")).
-  enablePlugins(BuildInfoPlugin).
-  settings(
+ThisBuild / scalaVersion := "2.12.12"
+ThisBuild / organization := "com.example"
+ThisBuild / version := "0.1"
+ThisBuild / homepage := Some(url("http://example.com"))
+ThisBuild / licenses := Seq("MIT License" -> url("https://github.com/sbt/sbt-buildinfo/blob/master/LICENSE"))
+
+lazy val root = (project in file("."))
+  .enablePlugins(BuildInfoPlugin)
+  .settings(
     name := "helloworld",
-    version := "0.1",
-    scalaVersion := "2.12.7",
     buildInfoKeys := Seq(name, version),
     buildInfoPackage := "hello",
-    homepage := Some(url("http://example.com")),
-    licenses := Seq("MIT License" -> url("https://github.com/sbt/sbt-buildinfo/blob/master/LICENSE")),
+    scalacOptions ++= Seq("-Xlint", "-Xfatal-warnings", "-Yno-imports"),
     check := {
       val dir = (sourceManaged in Compile).value
       val f = dir / "sbt-buildinfo" / ("%s.scala" format "BuildInfo")
       val lines = scala.io.Source.fromFile(f).getLines.toList
       lines match {
-        case """// $COVERAGE-OFF$""" :: 
+        case """// $COVERAGE-OFF$""" ::
              """package hello""" ::
              """""" ::
              """import scala.Predef._""" ::

--- a/src/sbt-test/sbt-buildinfo/caseclassrenderer/build.sbt
+++ b/src/sbt-test/sbt-buildinfo/caseclassrenderer/build.sbt
@@ -2,12 +2,15 @@ import sbtbuildinfo.ScalaCaseClassRenderer
 
 lazy val check = taskKey[Unit]("checks this plugin")
 
-lazy val root = (project in file(".")).
-  enablePlugins(BuildInfoPlugin).
-  settings(
+ThisBuild / version := "0.1"
+ThisBuild / scalaVersion := "2.12.12"
+ThisBuild / homepage := Some(url("http://example.com"))
+ThisBuild / licenses := Seq("MIT License" -> url("https://github.com/sbt/sbt-buildinfo/blob/master/LICENSE"))
+
+lazy val root = (project in file("."))
+  .enablePlugins(BuildInfoPlugin)
+  .settings(
     name := "helloworld",
-    version := "0.1",
-    scalaVersion := "2.11.12",
     buildInfoKeys := Seq(
       name,
       BuildInfoKey.map(version) { case (n, v) => "projectVersion" -> v.toDouble },
@@ -24,15 +27,13 @@ lazy val root = (project in file(".")).
     buildInfoOptions += BuildInfoOption.Traits("traits.MyCustomTrait"),
     buildInfoRenderFactory := ScalaCaseClassRenderer.apply,
     buildInfoPackage := "hello",
-    homepage := Some(url("http://example.com")),
-    licenses := Seq("MIT License" -> url("https://github.com/sbt/sbt-buildinfo/blob/master/LICENSE")),
     scalacOptions ++= Seq("-Ywarn-unused-import", "-Xfatal-warnings", "-Yno-imports"),
     libraryDependencies += "org.scala-lang.modules" %% "scala-xml" % "1.0.5",
     check := {
       val f = (sourceManaged in Compile).value / "sbt-buildinfo" / ("%s.scala" format "BuildInfo")
       val lines = scala.io.Source.fromFile(f).getLines.toList
       lines match {
-        case """// $COVERAGE-OFF$""" :: 
+        case """// $COVERAGE-OFF$""" ::
           """package hello""" ::
           """""" ::
           """import scala.Predef._""" ::
@@ -60,14 +61,14 @@ lazy val root = (project in file(".")).
           """  def apply(): BuildInfo = new BuildInfo(""" ::
           """    name = "helloworld",""" ::
           """    projectVersion = 0.1,""" ::
-          """    scalaVersion = "2.11.12",""" ::
+          """    scalaVersion = "2.12.12",""" ::
           """    ivyXML = scala.collection.immutable.Seq(),""" ::
           """    homepage = scala.Some(new java.net.URL("http://example.com")),""" ::
           """    licenses = scala.collection.immutable.Seq(("MIT License" -> new java.net.URL("https://github.com/sbt/sbt-buildinfo/blob/master/LICENSE"))),""" ::
           """    apiMappings = Map(),""" ::
           """    isSnapshot = false,""" ::
           """    year = 2012,""" ::
-          """    sym = 'Foo,""" ::
+          """    sym = scala.Symbol("Foo"),""" ::
           """    buildTime = 1234L,""" ::
           targetInfo ::
           """  val get = apply()""" ::

--- a/src/sbt-test/sbt-buildinfo/caseclassrenderer/test
+++ b/src/sbt-test/sbt-buildinfo/caseclassrenderer/test
@@ -1,4 +1,4 @@
 > compile
-$ exists target/scala-2.11/src_managed/main/sbt-buildinfo/BuildInfo.scala
+$ exists target/scala-2.12/src_managed/main/sbt-buildinfo/BuildInfo.scala
 
 > check

--- a/src/sbt-test/sbt-buildinfo/finalcaseobjectrenderer/build.sbt
+++ b/src/sbt-test/sbt-buildinfo/finalcaseobjectrenderer/build.sbt
@@ -2,12 +2,15 @@ import sbtbuildinfo.ScalaFinalCaseObjectRenderer
 
 lazy val check = taskKey[Unit]("checks this plugin")
 
+ThisBuild / version := "0.1"
+ThisBuild / scalaVersion := "2.12.12"
+ThisBuild / homepage := Some(url("http://example.com"))
+ThisBuild / licenses := Seq("MIT License" -> url("https://github.com/sbt/sbt-buildinfo/blob/master/LICENSE"))
+
 lazy val root = (project in file(".")).
   enablePlugins(BuildInfoPlugin).
   settings(
     name := "helloworld",
-    version := "0.1",
-    scalaVersion := "2.12.7",
     TaskKey[Classpath]("someCp") := Seq(Attributed.blank(file("/tmp/f.txt"))),
     buildInfoKeys := Seq[BuildInfoKey](
       name,
@@ -26,8 +29,6 @@ lazy val root = (project in file(".")).
     buildInfoOptions += BuildInfoOption.Traits("traits.MyCustomTrait"),
     buildInfoRenderFactory := ScalaFinalCaseObjectRenderer.apply,
     buildInfoPackage := "hello",
-    homepage := Some(url("http://example.com")),
-    licenses := Seq("MIT License" -> url("https://github.com/sbt/sbt-buildinfo/blob/master/LICENSE")),
     scalacOptions ++= Seq("-Ywarn-unused-import", "-Xfatal-warnings", "-Yno-imports"),
     libraryDependencies += "org.scala-lang.modules" %% "scala-xml" % "1.0.5",
     check := {
@@ -45,8 +46,8 @@ lazy val root = (project in file(".")).
           """  final val name: String = "helloworld"""" ::
           """  /** The value is 0.1. */"""::
           """  final val projectVersion = 0.1""" ::
-          """  /** The value is "2.12.7". */""" ::
-          """  final val scalaVersion: String = "2.12.7"""" ::
+          """  /** The value is "2.12.12". */""" ::
+          """  final val scalaVersion: String = "2.12.12"""" ::
           """  /** The value is scala.collection.immutable.Seq(). */""" ::
           """  final val ivyXML: scala.xml.NodeSeq = scala.collection.immutable.Seq()""" ::
           """  /** The value is scala.Some(new java.net.URL("http://example.com")). */""" ::
@@ -59,8 +60,8 @@ lazy val root = (project in file(".")).
           """  final val isSnapshot: scala.Boolean = false""" ::
           """  /** The value is 2012. */""" ::
           """  final val year: scala.Int = 2012""" ::
-          """  /** The value is 'Foo. */""" ::
-          """  final val sym: scala.Symbol = 'Foo""" ::
+          """  /** The value is scala.Symbol("Foo"). */""" ::
+          """  final val sym: scala.Symbol = scala.Symbol("Foo")""" ::
           """  /** The value is 1234L. */""" ::
           """  final val buildTime: scala.Long = 1234L""" ::
           """  /** The value is scala.collection.immutable.Seq(new java.io.File("/tmp/f.txt")). */""" ::

--- a/src/sbt-test/sbt-buildinfo/finalcaseobjectrenderer/build.sbt
+++ b/src/sbt-test/sbt-buildinfo/finalcaseobjectrenderer/build.sbt
@@ -9,7 +9,7 @@ lazy val root = (project in file(".")).
     version := "0.1",
     scalaVersion := "2.12.7",
     TaskKey[Classpath]("someCp") := Seq(Attributed.blank(file("/tmp/f.txt"))),
-    buildInfoKeys := BuildInfoKey.ofN(
+    buildInfoKeys := Seq[BuildInfoKey](
       name,
       BuildInfoKey.map(version) { case (n, v) => "projectVersion" -> v.toDouble },
       scalaVersion,

--- a/src/sbt-test/sbt-buildinfo/multi/test
+++ b/src/sbt-test/sbt-buildinfo/multi/test
@@ -1,6 +1,6 @@
 > project root
 
 > compile
-$ exists app/target/scala-2.12/src_managed/main/sbt-buildinfo/BuildInfo.scala
+$ exists app/target/scala-2.13/src_managed/main/sbt-buildinfo/BuildInfo.scala
 
 > check

--- a/src/sbt-test/sbt-buildinfo/options/build.sbt
+++ b/src/sbt-test/sbt-buildinfo/options/build.sbt
@@ -1,14 +1,15 @@
 lazy val check = taskKey[Unit]("checks this plugin")
 
-lazy val root = (project in file(".")).
-  enablePlugins(BuildInfoPlugin).
-  settings(
+ThisBuild / version := "0.1"
+ThisBuild / scalaVersion := "2.12.12"
+
+lazy val root = (project in file("."))
+  .enablePlugins(BuildInfoPlugin)
+  .settings(
     name := "helloworld",
-    version := "0.1",
-    scalaVersion := "2.12.7",
     buildInfoKeys := Seq(
       name,
-      scalaVersion
+      scalaVersion,
     ),
     buildInfoPackage := "hello",
     buildInfoOptions ++= Seq(
@@ -19,6 +20,7 @@ lazy val root = (project in file(".")).
       BuildInfoOption.PackagePrivate),
     homepage := Some(url("http://example.com")),
     licenses := Seq("MIT License" -> url("https://github.com/sbt/sbt-buildinfo/blob/master/LICENSE")),
+    scalacOptions ++= Seq("-Xlint", "-Xfatal-warnings"),
     check := {
       val f = (sourceManaged in Compile).value / "sbt-buildinfo" / ("%s.scala" format "BuildInfo")
       val lines = scala.io.Source.fromFile(f).getLines.toList
@@ -32,8 +34,8 @@ lazy val root = (project in file(".")).
               """private[hello] case object BuildInfo extends TestTrait1 with TestTrait2 with TestTrait3 {""" ::
               """  /** The value is "helloworld". */""" ::
               """  val name: String = "helloworld"""" ::
-              """  /** The value is "2.12.7". */""" ::
-              """  val scalaVersion: String = "2.12.7"""" ::
+              """  /** The value is "2.12.12". */""" ::
+              """  val scalaVersion: String = "2.12.12"""" ::
               """  override val toString: String = {""" ::
               """    "name: %s, scalaVersion: %s".format(""" ::
               """      name, scalaVersion""" ::
@@ -48,8 +50,8 @@ lazy val root = (project in file(".")).
               """    value match {""" ::
               """      case elem: Seq[_] => elem.map(toJsonValue).mkString("[", ",", "]")""" ::
               """      case elem: Option[_] => elem.map(toJsonValue).getOrElse("null")""" ::
-              """      case elem: Map[String, Any] => elem.map {""" ::
-              """        case (k, v) => toJsonValue(k) + ":" + toJsonValue(v)""" ::
+              """      case elem: Map[_, Any] => elem.map {""" ::
+              """        case (k, v) => toJsonValue(k.toString) + ":" + toJsonValue(v)""" ::
               """      }.mkString("{", ", ", "}")""" ::
               """      case d: Double => d.toString""" ::
               """      case f: Float => f.toString""" ::

--- a/src/sbt-test/sbt-buildinfo/simple/build.sbt
+++ b/src/sbt-test/sbt-buildinfo/simple/build.sbt
@@ -7,7 +7,7 @@ lazy val root = (project in file(".")).
     version := "0.1",
     scalaVersion := "2.12.7",
     TaskKey[Classpath]("someCp") := Seq(Attributed.blank(file("/tmp/f.txt"))),
-    buildInfoKeys := BuildInfoKey.ofN(
+    buildInfoKeys := Seq[BuildInfoKey](
       name,
       BuildInfoKey.map(version) { case (n, v) => "projectVersion" -> v.toDouble },
       scalaVersion,

--- a/src/sbt-test/sbt-buildinfo/simple/build.sbt
+++ b/src/sbt-test/sbt-buildinfo/simple/build.sbt
@@ -1,11 +1,14 @@
 lazy val check = taskKey[Unit]("checks this plugin")
 
-lazy val root = (project in file(".")).
-  enablePlugins(BuildInfoPlugin).
-  settings(
+ThisBuild / version := "0.1"
+ThisBuild / scalaVersion := "2.13.3"
+ThisBuild / homepage := Some(url("http://example.com"))
+ThisBuild / licenses := Seq("MIT License" -> url("https://github.com/sbt/sbt-buildinfo/blob/master/LICENSE"))
+
+lazy val root = (project in file("."))
+  .enablePlugins(BuildInfoPlugin)
+  .settings(
     name := "helloworld",
-    version := "0.1",
-    scalaVersion := "2.12.7",
     TaskKey[Classpath]("someCp") := Seq(Attributed.blank(file("/tmp/f.txt"))),
     buildInfoKeys := Seq[BuildInfoKey](
       name,
@@ -23,11 +26,10 @@ lazy val root = (project in file(".")).
       target
     ),
     buildInfoPackage := "hello",
-    homepage := Some(url("http://example.com")),
-    licenses := Seq("MIT License" -> url("https://github.com/sbt/sbt-buildinfo/blob/master/LICENSE")),
-    scalacOptions ++= Seq("-Ywarn-unused-import", "-Xfatal-warnings", "-Yno-imports"),
-    libraryDependencies += "org.scala-lang.modules" %% "scala-xml" % "1.0.5",
+    scalacOptions ++= Seq("-Xlint", "-Xfatal-warnings", "-Yno-imports"),
+    libraryDependencies += "org.scala-lang.modules" %% "scala-xml" % "1.3.0",
     check := {
+      val sv = scalaVersion.value
       val f = (sourceManaged in Compile).value / "sbt-buildinfo" / ("%s.scala" format "BuildInfo")
       val lines = scala.io.Source.fromFile(f).getLines.toList
       lines match {
@@ -42,8 +44,8 @@ lazy val root = (project in file(".")).
              """  val name: String = "helloworld"""" ::
              """  /** The value is 0.1. */"""::
              """  val projectVersion = 0.1""" ::
-             """  /** The value is "2.12.7". */""" ::
-             """  val scalaVersion: String = "2.12.7"""" ::
+             scalaVersionInfoComment ::
+             scalaVersionInfo ::
              """  /** The value is scala.collection.immutable.Seq(). */""" ::
              """  val ivyXML: scala.xml.NodeSeq = scala.collection.immutable.Seq()""" ::
              """  /** The value is scala.Some(new java.net.URL("http://example.com")). */""" ::
@@ -56,8 +58,8 @@ lazy val root = (project in file(".")).
              """  val isSnapshot: scala.Boolean = false""" ::
              """  /** The value is 2012. */""" ::
              """  val year: scala.Int = 2012""" ::
-             """  /** The value is 'Foo. */""" ::
-             """  val sym: scala.Symbol = 'Foo""" ::
+             """  /** The value is scala.Symbol("Foo"). */""" ::
+             """  val sym: scala.Symbol = scala.Symbol("Foo")""" ::
              """  /** The value is 1234L. */""" ::
              """  val buildTime: scala.Long = 1234L""" ::
              """  /** The value is scala.collection.immutable.Seq(new java.io.File("/tmp/f.txt")). */""" ::
@@ -70,7 +72,8 @@ lazy val root = (project in file(".")).
              """    )""" ::
              """  }""" ::
              """}""" ::
-             """// $COVERAGE-ON$""" :: Nil if (targetInfo contains "val target: java.io.File = new java.io.File(") =>
+             """// $COVERAGE-ON$""" :: Nil if (targetInfo contains "val target: java.io.File = new java.io.File(") &&
+             (scalaVersionInfo.trim == s"""val scalaVersion: String = "$sv"""") => ()
         case _ => sys.error("unexpected output: \n" + lines.mkString("\n"))
       }
       ()

--- a/src/sbt-test/sbt-buildinfo/simple/test
+++ b/src/sbt-test/sbt-buildinfo/simple/test
@@ -1,4 +1,10 @@
 > compile
-$ exists target/scala-2.12/src_managed/main/sbt-buildinfo/BuildInfo.scala
+> doc
+$ exists target/scala-2.13/src_managed/main/sbt-buildinfo/BuildInfo.scala
+> check
 
+> ++2.12.12!
+> compile
+> doc
+$ exists target/scala-2.12/src_managed/main/sbt-buildinfo/BuildInfo.scala
 > check

--- a/src/sbt-test/sbt-buildinfo/task/build.sbt
+++ b/src/sbt-test/sbt-buildinfo/task/build.sbt
@@ -2,25 +2,31 @@ import StableState.{ counterOutOfTaskGraph, counterInTaskGraph }
 
 scalaVersion in ThisBuild := "2.12.4"
 
-val projOutOfTaskGraph1 = project settings (
-  sourceGenerators in Compile += Def.task { counterOutOfTaskGraph.incrementAndGet(); Nil }.taskValue
-)
+val projOutOfTaskGraph1 = project
+  .settings (
+    sourceGenerators in Compile += Def.task { counterOutOfTaskGraph.incrementAndGet(); Nil }.taskValue
+  )
 
-val projOutOfTaskGraph2 = project dependsOn projOutOfTaskGraph1 settings (
-  BuildInfoPlugin.buildInfoDefaultSettings,
-  addBuildInfoToConfig(Test),
-  buildInfoKeys in Test += BuildInfoKey.outOfGraphUnsafe(fullClasspath in Compile),
-)
+val projOutOfTaskGraph2 = project
+  .dependsOn(projOutOfTaskGraph1)
+  .settings (
+    BuildInfoPlugin.buildInfoDefaultSettings,
+    addBuildInfoToConfig(Test),
+    buildInfoKeys in Test += BuildInfoKey.outOfGraphUnsafe(fullClasspath in Compile),
+  )
 
-val projInTaskGraph1 = project settings (
-  sourceGenerators in Compile += Def.task { counterInTaskGraph.incrementAndGet(); Nil }.taskValue
-)
+val projInTaskGraph1 = project
+  .settings (
+    sourceGenerators in Compile += Def.task { counterInTaskGraph.incrementAndGet(); Nil }.taskValue
+  )
 
-val projInTaskGraph2 = project dependsOn projInTaskGraph1 settings (
-  BuildInfoPlugin.buildInfoDefaultSettings,
-  addBuildInfoToConfig(Test),
-  buildInfoKeys in Test += BuildInfoKey.of(fullClasspath in Compile)
-)
+val projInTaskGraph2 = project
+  .dependsOn(projInTaskGraph1)
+  .settings (
+    BuildInfoPlugin.buildInfoDefaultSettings,
+    addBuildInfoToConfig(Test),
+    buildInfoKeys in Test += (fullClasspath in Compile: BuildInfoKey)
+  )
 
 TaskKey[Unit]("checkOutOfTaskGraph") := {
   val value = counterOutOfTaskGraph.get()

--- a/src/sbt-test/sbt-buildinfo/task/build.sbt
+++ b/src/sbt-test/sbt-buildinfo/task/build.sbt
@@ -1,6 +1,9 @@
 import StableState.{ counterOutOfTaskGraph, counterInTaskGraph }
 
-scalaVersion in ThisBuild := "2.12.4"
+ThisBuild / version := "0.1"
+ThisBuild / scalaVersion := "2.12.12"
+ThisBuild / homepage := Some(url("http://example.com"))
+ThisBuild / licenses := Seq("MIT License" -> url("https://github.com/sbt/sbt-buildinfo/blob/master/LICENSE"))
 
 val projOutOfTaskGraph1 = project
   .settings (

--- a/src/sbt-test/sbt-buildinfo/usepackageaspath/build.sbt
+++ b/src/sbt-test/sbt-buildinfo/usepackageaspath/build.sbt
@@ -1,12 +1,15 @@
 lazy val check = taskKey[Unit]("checks this plugin")
 
-lazy val root = (project in file(".")).
-  enablePlugins(BuildInfoPlugin).
-  settings(
+ThisBuild / version := "0.1"
+ThisBuild / scalaVersion := "2.12.12"
+ThisBuild / homepage := Some(url("http://example.com"))
+ThisBuild / licenses := Seq("MIT License" -> url("https://github.com/sbt/sbt-buildinfo/blob/master/LICENSE"))
+
+lazy val root = (project in file("."))
+  .enablePlugins(BuildInfoPlugin)
+  .settings(
     name := "helloworld",
-    version := "0.1",
-    scalaVersion := "2.12.7",
-    libraryDependencies += "org.scala-lang.modules" %% "scala-xml" % "1.1.0",
+    libraryDependencies += "org.scala-lang.modules" %% "scala-xml" % "1.3.0",
     buildInfoKeys := Seq[BuildInfoKey](
       name,
       BuildInfoKey.map(version) { case (n, v) => "projectVersion" -> v.toDouble },
@@ -23,8 +26,7 @@ lazy val root = (project in file(".")).
     ),
     buildInfoPackage := "foo.bar.baz",
     buildInfoUsePackageAsPath := true,
-    homepage := Some(url("http://example.com")),
-    licenses := Seq("MIT License" -> url("https://github.com/sbt/sbt-buildinfo/blob/master/LICENSE")),
+    scalacOptions ++= Seq("-Ywarn-unused-import", "-Xfatal-warnings", "-Yno-imports"),
     check := {
       val f = (sourceManaged in Compile).value / "foo" / "bar" / "baz" / ("%s.scala" format "BuildInfo")
       val lines = scala.io.Source.fromFile(f).getLines.toList
@@ -40,8 +42,8 @@ lazy val root = (project in file(".")).
              """  val name: String = "helloworld"""" ::
              """  /** The value is 0.1. */"""::
              """  val projectVersion = 0.1""" ::
-             """  /** The value is "2.12.7". */""" ::
-             """  val scalaVersion: String = "2.12.7"""" ::
+             """  /** The value is "2.12.12". */""" ::
+             """  val scalaVersion: String = "2.12.12"""" ::
              """  /** The value is scala.collection.immutable.Seq(). */""" ::
              """  val ivyXML: scala.xml.NodeSeq = scala.collection.immutable.Seq()""" ::
              """  /** The value is scala.Some(new java.net.URL("http://example.com")). */""" ::
@@ -54,8 +56,8 @@ lazy val root = (project in file(".")).
              """  val isSnapshot: scala.Boolean = false""" ::
              """  /** The value is 2012. */""" ::
              """  val year: scala.Int = 2012""" ::
-             """  /** The value is 'Foo. */""" ::
-             """  val sym: scala.Symbol = 'Foo""" ::
+             """  /** The value is scala.Symbol("Foo"). */""" ::
+             """  val sym: scala.Symbol = scala.Symbol("Foo")""" ::
              """  /** The value is 1234L. */""" ::
              """  val buildTime: scala.Long = 1234L""" ::
              targetInfoComment ::

--- a/src/sbt-test/sbt-buildinfo/usepackageaspath/build.sbt
+++ b/src/sbt-test/sbt-buildinfo/usepackageaspath/build.sbt
@@ -7,7 +7,7 @@ lazy val root = (project in file(".")).
     version := "0.1",
     scalaVersion := "2.12.7",
     libraryDependencies += "org.scala-lang.modules" %% "scala-xml" % "1.1.0",
-    buildInfoKeys := BuildInfoKey.ofN(
+    buildInfoKeys := Seq[BuildInfoKey](
       name,
       BuildInfoKey.map(version) { case (n, v) => "projectVersion" -> v.toDouble },
       scalaVersion,

--- a/src/test/scala/sbtbuildinfo/BuildInfoKeySpec.scala
+++ b/src/test/scala/sbtbuildinfo/BuildInfoKeySpec.scala
@@ -36,33 +36,4 @@ object BuildInfoKeySpec {
     BuildInfoKey.map(version) { case (_, v) => "projectVersion" -> v.toDouble },
     BuildInfoKey.map(fullClasspath) { case (ident, cp) => ident -> cp.files },
   )
-
-
-  buildInfoKeys  := BuildInfoKey.ofN(name, version)           // test `:=` works with setting keys
-  buildInfoKeys  := BuildInfoKey.ofN(products, fullClasspath) // test `:=` works with task keys
-  buildInfoKeys  := BuildInfoKey.ofN(name, fullClasspath)     // test `:=` works with setting and task keys
-  buildInfoKeys  := BuildInfoKey.ofN(                         // test `:=` works with misc things
-    name,
-    fullClasspath,
-    "year" -> 2012,
-    BuildInfoKey.action("buildTime") { 1234L },
-    BuildInfoKey.map(version) { case (_, v) => "projectVersion" -> v.toDouble },
-    BuildInfoKey.map(fullClasspath) { case (ident, cp) => ident -> cp.files },
-  )
-
-  buildInfoKeys  += BuildInfoKey.of(name)                     // test `+=` works with a setting key
-  buildInfoKeys  += BuildInfoKey.of(fullClasspath)            // test `+=` works with a task key
-
-  buildInfoKeys ++= BuildInfoKey.ofN(name, version)           // test `++=` works with setting keys
-  buildInfoKeys ++= BuildInfoKey.ofN(fullClasspath)           // test `++=` works with 1 task key
-  buildInfoKeys ++= BuildInfoKey.ofN(products, fullClasspath) // test `++=` works with n task keys
-  buildInfoKeys ++= BuildInfoKey.ofN(name, fullClasspath)     // test `++=` works with setting and task keys
-  buildInfoKeys ++= BuildInfoKey.ofN(                         // test `++=` works with misc things
-    name,
-    fullClasspath,
-    "year" -> 2012,
-    BuildInfoKey.action("buildTime") { 1234L },
-    BuildInfoKey.map(version) { case (_, v) => "projectVersion" -> v.toDouble },
-    BuildInfoKey.map(fullClasspath) { case (ident, cp) => ident -> cp.files },
-  )
 }


### PR DESCRIPTION
Fixes #162

1. Deprecate `BuildInfoKey.of(...)` and `BuildInfoKey.ofN(...)` that was introduced in 0.8.0, because they are no longer the recommended route since 0.9.0.
2. Fix pattern matching warning about `Map[String, Any]`.
3. Avoid using symbol literals.