### PR TITLE
Updating README using latest released tag

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -16,7 +16,7 @@ For sbt 1.x add sbt-buildinfo as a dependency in `project/plugins.sbt`:
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "x.y.z")
 ```
 
-- For `sbt >= 0.13.6`, see [0.9.0](https://github.com/sbt/sbt-buildinfo/tree/v0.9.0).
+- For `sbt >= 0.13.6`, see [0.10.0](https://github.com/sbt/sbt-buildinfo/tree/v0.10.0).
 - For `sbt < 0.13.6`, see [0.3.2](https://github.com/sbt/sbt-buildinfo/tree/0.3.2).
 
 Usage


### PR DESCRIPTION
Since the latest released version is `0.10.0`, it makes sense to mention it in the readme