### PR TITLE
Correcting typo (can can)

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -59,7 +59,7 @@ case object BuildInfo {
 
 As this is generated source it will be found under `target`, specifically for a Scala 2.11 project under `target/scala-2.11/src_managed/main/sbt-buildinfo`
 
-Customize `buildInfoKeys` by adding whatever keys you want to have in `BuildInfo`. You can use `BuildInfoKey.map` to change the generated field name and value, add new fields with tuples, or add new fields with values computed at build-time. Note: `BuildInfoKey.map` can can handle both `SettingKey[T]` and `TaskKey[T]` types as arguments:
+Customize `buildInfoKeys` by adding whatever keys you want to have in `BuildInfo`. You can use `BuildInfoKey.map` to change the generated field name and value, add new fields with tuples, or add new fields with values computed at build-time. Note: `BuildInfoKey.map` can handle both `SettingKey[T]` and `TaskKey[T]` types as arguments:
 
 ```scala
 buildInfoKeys ++= Seq[BuildInfoKey](


### PR DESCRIPTION
Fixing a typo: the word `can` was written twice