### PR TITLE
Add Java time objects as valid BuildInfoKey values

### DIFF
--- a/src/main/scala/sbtbuildinfo/JavaRenderer.scala
+++ b/src/main/scala/sbtbuildinfo/JavaRenderer.scala
@@ -177,6 +177,9 @@ abstract class JavaRenderer(pkg: String, cl: String, makeStatic: Boolean) extend
             x0 <- tpeToReturnType(arg0)
             x1 <- tpeToReturnType(arg1)
           } yield s"java.util.Map.Entry<$x0, $x1>"
+        
+        case TypeExpression("java.time.LocalDate", Nil) => Some("java.time.LocalDate")
+
         case _ => None
       }
     tpeToReturnType(typeExpr)
@@ -198,6 +201,7 @@ abstract class JavaRenderer(pkg: String, cl: String, makeStatic: Boolean) extend
     case url: java.net.URL       => "internalAsUrl(%s)" format quote(url.toString)
     case file: java.io.File      => "new java.io.File(%s)" format quote(file.toString)
     case attr: sbt.Attributed[_] => quote(attr.data)
+    case date: java.time.LocalDate => "java.time.LocalDate.parse(%s)" format quote(date.toString)
     case s                       => "\"%s\"" format encodeStringLiteral(s.toString)
   }
 

--- a/src/main/scala/sbtbuildinfo/JavaRenderer.scala
+++ b/src/main/scala/sbtbuildinfo/JavaRenderer.scala
@@ -179,6 +179,7 @@ abstract class JavaRenderer(pkg: String, cl: String, makeStatic: Boolean) extend
           } yield s"java.util.Map.Entry<$x0, $x1>"
         
         case TypeExpression("java.time.LocalDate", Nil) => Some("java.time.LocalDate")
+        case TypeExpression("java.time.Instant", Nil) => Some("java.time.Instant")
 
         case _ => None
       }
@@ -201,7 +202,8 @@ abstract class JavaRenderer(pkg: String, cl: String, makeStatic: Boolean) extend
     case url: java.net.URL       => "internalAsUrl(%s)" format quote(url.toString)
     case file: java.io.File      => "new java.io.File(%s)" format quote(file.toString)
     case attr: sbt.Attributed[_] => quote(attr.data)
-    case date: java.time.LocalDate => "java.time.LocalDate.parse(%s)" format quote(date.toString)
+    case date: java.time.LocalDate  => "java.time.LocalDate.parse(%s)" format quote(date.toString)
+    case instant: java.time.Instant => "java.time.Instant.parse(%s)" format quote(instant.toString)
     case s                       => "\"%s\"" format encodeStringLiteral(s.toString)
   }
 

--- a/src/main/scala/sbtbuildinfo/ScalaRenderer.scala
+++ b/src/main/scala/sbtbuildinfo/ScalaRenderer.scala
@@ -78,6 +78,9 @@ abstract class ScalaRenderer extends BuildInfoRenderer {
             x0 <- tpeToReturnType(arg0)
             x1 <- tpeToReturnType(arg1)
           } yield s"($x0, $x1)"
+
+        case TypeExpression("java.time.LocalDate", Nil) => Some("java.time.LocalDate")
+
         case _ => None
       }
     tpeToReturnType(typeExpr)
@@ -96,6 +99,7 @@ abstract class ScalaRenderer extends BuildInfoRenderer {
     case url: java.net.URL  => "new java.net.URL(%s)" format quote(url.toString)
     case file: java.io.File => "new java.io.File(%s)" format quote(file.toString)
     case attr: sbt.Attributed[_] => quote(attr.data)
+    case date: java.time.LocalDate => "java.time.LocalDate.parse(%s)" format quote(date.toString)
     case s                  => "\"%s\"" format encodeStringLiteral(s.toString)
   }
 

--- a/src/main/scala/sbtbuildinfo/ScalaRenderer.scala
+++ b/src/main/scala/sbtbuildinfo/ScalaRenderer.scala
@@ -80,6 +80,7 @@ abstract class ScalaRenderer extends BuildInfoRenderer {
           } yield s"($x0, $x1)"
 
         case TypeExpression("java.time.LocalDate", Nil) => Some("java.time.LocalDate")
+        case TypeExpression("java.time.Instant", Nil)   => Some("java.time.Instant")
 
         case _ => None
       }
@@ -99,7 +100,8 @@ abstract class ScalaRenderer extends BuildInfoRenderer {
     case url: java.net.URL  => "new java.net.URL(%s)" format quote(url.toString)
     case file: java.io.File => "new java.io.File(%s)" format quote(file.toString)
     case attr: sbt.Attributed[_] => quote(attr.data)
-    case date: java.time.LocalDate => "java.time.LocalDate.parse(%s)" format quote(date.toString)
+    case date: java.time.LocalDate  => "java.time.LocalDate.parse(%s)" format quote(date.toString)
+    case instant: java.time.Instant => "java.time.Instant.parse(%s)" format quote(instant.toString)
     case s                  => "\"%s\"" format encodeStringLiteral(s.toString)
   }
 

--- a/src/sbt-test/sbt-buildinfo/caseclassrenderer/build.sbt
+++ b/src/sbt-test/sbt-buildinfo/caseclassrenderer/build.sbt
@@ -23,6 +23,7 @@ lazy val root = (project in file("."))
       "year" -> 2012,
       "sym" -> 'Foo,
       "now" -> java.time.LocalDate.parse("2021-11-02"),
+      "instant" -> java.time.Instant.parse("2021-11-02T01:23:45.678Z"),
       BuildInfoKey.action("buildTime") { 1234L },
       target),
     buildInfoOptions ++= Seq(
@@ -57,6 +58,7 @@ lazy val root = (project in file("."))
           """  year: scala.Int,""" ::
           """  sym: scala.Symbol,""" ::
           """  now: java.time.LocalDate,""" ::
+          """  instant: java.time.Instant,""" ::
           """  buildTime: scala.Long,""" ::
           """  target: java.io.File""" ::
           """) extends traits.MyCustomTrait {""" ::
@@ -73,6 +75,7 @@ lazy val root = (project in file("."))
           """    "year" -> year,""" ::
           """    "sym" -> sym,""" ::
           """    "now" -> now,""" ::
+          """    "instant" -> instant,""" ::
           """    "buildTime" -> buildTime,""" ::
           """    "target" -> target)""" ::
           """""" ::
@@ -111,6 +114,7 @@ lazy val root = (project in file("."))
           """    year = 2012,""" ::
           """    sym = scala.Symbol("Foo"),""" ::
           """    now = java.time.LocalDate.parse("2021-11-02"),""" ::
+          """    instant = java.time.Instant.parse("2021-11-02T01:23:45.678Z"),""" ::
           """    buildTime = 1234L,""" ::
           targetInfo ::
           """  val get = apply()""" ::

--- a/src/sbt-test/sbt-buildinfo/caseclassrenderer/build.sbt
+++ b/src/sbt-test/sbt-buildinfo/caseclassrenderer/build.sbt
@@ -22,6 +22,7 @@ lazy val root = (project in file("."))
       isSnapshot,
       "year" -> 2012,
       "sym" -> 'Foo,
+      "now" -> java.time.LocalDate.parse("2021-11-02"),
       BuildInfoKey.action("buildTime") { 1234L },
       target),
     buildInfoOptions ++= Seq(
@@ -55,6 +56,7 @@ lazy val root = (project in file("."))
           """  isSnapshot: scala.Boolean,""" ::
           """  year: scala.Int,""" ::
           """  sym: scala.Symbol,""" ::
+          """  now: java.time.LocalDate,""" ::
           """  buildTime: scala.Long,""" ::
           """  target: java.io.File""" ::
           """) extends traits.MyCustomTrait {""" ::
@@ -70,6 +72,7 @@ lazy val root = (project in file("."))
           """    "isSnapshot" -> isSnapshot,""" ::
           """    "year" -> year,""" ::
           """    "sym" -> sym,""" ::
+          """    "now" -> now,""" ::
           """    "buildTime" -> buildTime,""" ::
           """    "target" -> target)""" ::
           """""" ::
@@ -107,6 +110,7 @@ lazy val root = (project in file("."))
           """    isSnapshot = false,""" ::
           """    year = 2012,""" ::
           """    sym = scala.Symbol("Foo"),""" ::
+          """    now = java.time.LocalDate.parse("2021-11-02"),""" ::
           """    buildTime = 1234L,""" ::
           targetInfo ::
           """  val get = apply()""" ::

--- a/src/sbt-test/sbt-buildinfo/constantvalue/build.sbt
+++ b/src/sbt-test/sbt-buildinfo/constantvalue/build.sbt
@@ -23,6 +23,7 @@ lazy val root = (project in file(".")).
       "year" -> 2012,
       "sym" -> 'Foo,
       "now" -> java.time.LocalDate.parse("2021-11-02"),
+      "instant" -> java.time.Instant.parse("2021-11-02T01:23:45.678Z"),
       BuildInfoKey.action("buildTime") { 1234L },
       TaskKey[Classpath]("someCp"),
       target),
@@ -66,6 +67,8 @@ lazy val root = (project in file(".")).
           """  final val sym = scala.Symbol("Foo")""" ::
           """  /** The value is java.time.LocalDate.parse("2021-11-02"). */""" ::
           """  val now: java.time.LocalDate = java.time.LocalDate.parse("2021-11-02")""" ::
+          """  /** The value is java.time.Instant.parse("2021-11-02T01:23:45.678Z"). */""" ::
+          """  val instant: java.time.Instant = java.time.Instant.parse("2021-11-02T01:23:45.678Z")""" ::
           """  /** The value is 1234L. */""" ::
           """  final val buildTime = 1234L""" ::
           """  /** The value is scala.collection.immutable.Seq(new java.io.File("/tmp/f.txt")). */""" ::
@@ -73,8 +76,8 @@ lazy val root = (project in file(".")).
           targetInfoComment ::
           targetInfo :: // """
           """  override val toString: String = {""" ::
-          """    "name: %s, version: %s, projectVersion: %s, scalaVersion: %s, ivyXML: %s, homepage: %s, licenses: %s, apiMappings: %s, isSnapshot: %s, year: %s, sym: %s, now: %s, buildTime: %s, someCp: %s, target: %s".format(""" ::
-          """      name, version, projectVersion, scalaVersion, ivyXML, homepage, licenses, apiMappings, isSnapshot, year, sym, now, buildTime, someCp, target""" ::
+          """    "name: %s, version: %s, projectVersion: %s, scalaVersion: %s, ivyXML: %s, homepage: %s, licenses: %s, apiMappings: %s, isSnapshot: %s, year: %s, sym: %s, now: %s, instant: %s, buildTime: %s, someCp: %s, target: %s".format(""" ::
+          """      name, version, projectVersion, scalaVersion, ivyXML, homepage, licenses, apiMappings, isSnapshot, year, sym, now, instant, buildTime, someCp, target""" ::
           """    )""" ::
           """  }""" ::
           """}""" ::

--- a/src/sbt-test/sbt-buildinfo/constantvalue/build.sbt
+++ b/src/sbt-test/sbt-buildinfo/constantvalue/build.sbt
@@ -22,6 +22,7 @@ lazy val root = (project in file(".")).
       isSnapshot,
       "year" -> 2012,
       "sym" -> 'Foo,
+      "now" -> java.time.LocalDate.parse("2021-11-02"),
       BuildInfoKey.action("buildTime") { 1234L },
       TaskKey[Classpath]("someCp"),
       target),
@@ -63,6 +64,8 @@ lazy val root = (project in file(".")).
           """  final val year = 2012""" ::
           """  /** The value is scala.Symbol("Foo"). */""" ::
           """  final val sym = scala.Symbol("Foo")""" ::
+          """  /** The value is java.time.LocalDate.parse("2021-11-02"). */""" ::
+          """  val now: java.time.LocalDate = java.time.LocalDate.parse("2021-11-02")""" ::
           """  /** The value is 1234L. */""" ::
           """  final val buildTime = 1234L""" ::
           """  /** The value is scala.collection.immutable.Seq(new java.io.File("/tmp/f.txt")). */""" ::
@@ -70,8 +73,8 @@ lazy val root = (project in file(".")).
           targetInfoComment ::
           targetInfo :: // """
           """  override val toString: String = {""" ::
-          """    "name: %s, version: %s, projectVersion: %s, scalaVersion: %s, ivyXML: %s, homepage: %s, licenses: %s, apiMappings: %s, isSnapshot: %s, year: %s, sym: %s, buildTime: %s, someCp: %s, target: %s".format(""" ::
-          """      name, version, projectVersion, scalaVersion, ivyXML, homepage, licenses, apiMappings, isSnapshot, year, sym, buildTime, someCp, target""" ::
+          """    "name: %s, version: %s, projectVersion: %s, scalaVersion: %s, ivyXML: %s, homepage: %s, licenses: %s, apiMappings: %s, isSnapshot: %s, year: %s, sym: %s, now: %s, buildTime: %s, someCp: %s, target: %s".format(""" ::
+          """      name, version, projectVersion, scalaVersion, ivyXML, homepage, licenses, apiMappings, isSnapshot, year, sym, now, buildTime, someCp, target""" ::
           """    )""" ::
           """  }""" ::
           """}""" ::

--- a/src/sbt-test/sbt-buildinfo/javasingletonrenderer/build.sbt
+++ b/src/sbt-test/sbt-buildinfo/javasingletonrenderer/build.sbt
@@ -24,6 +24,7 @@ lazy val root = (project in file("."))
       isSnapshot,
       "year" -> 2012,
       "sym" -> 'Foo,
+      "now" -> java.time.LocalDate.parse("2021-11-02"),
       BuildInfoKey.action("buildTime") { 1234L },
       target),
     buildInfoOptions ++= Seq(
@@ -62,14 +63,16 @@ lazy val root = (project in file("."))
           """  public final Integer year = 2012;""" ::
           """  /** The value is ("Foo").intern(). */""" ::
           """  public final String sym = ("Foo").intern();""" ::
+          """  /** The value is java.time.LocalDate.parse("2021-11-02"). */""" ::
+          """  public final java.time.LocalDate now = java.time.LocalDate.parse("2021-11-02");""" ::
           """  /** The value is 1234L. */""" ::
           """  public final Long buildTime = 1234L;""" ::
           targetInfoComment ::
           targetInfo ::
           """""" ::
           """  public String toString() {""" ::
-          """    return String.format("name: %s, scalaVersion: %s, homepage: %s, licenses: %s, apiMappings: %s, isSnapshot: %s, year: %s, sym: %s, buildTime: %s, target: %s",""" ::
-          """      name, scalaVersion, homepage, licenses, apiMappings, isSnapshot, year, sym, buildTime, target""" ::
+          """    return String.format("name: %s, scalaVersion: %s, homepage: %s, licenses: %s, apiMappings: %s, isSnapshot: %s, year: %s, sym: %s, now: %s, buildTime: %s, target: %s",""" ::
+          """      name, scalaVersion, homepage, licenses, apiMappings, isSnapshot, year, sym, now, buildTime, target""" ::
           """    );""" ::
           """  }""" ::
           """""" ::
@@ -83,6 +86,7 @@ lazy val root = (project in file("."))
           """    m.put("isSnapshot", isSnapshot);""" ::
           """    m.put("year", year);""" ::
           """    m.put("sym", sym);""" ::
+          """    m.put("now", now);""" ::
           """    m.put("buildTime", buildTime);""" ::
           """    m.put("target", target);""" ::
           """    return java.util.Collections.unmodifiableMap(m);""" ::

--- a/src/sbt-test/sbt-buildinfo/javasingletonrenderer/build.sbt
+++ b/src/sbt-test/sbt-buildinfo/javasingletonrenderer/build.sbt
@@ -25,6 +25,7 @@ lazy val root = (project in file("."))
       "year" -> 2012,
       "sym" -> 'Foo,
       "now" -> java.time.LocalDate.parse("2021-11-02"),
+      "instant" -> java.time.Instant.parse("2021-11-02T01:23:45.678Z"),
       BuildInfoKey.action("buildTime") { 1234L },
       target),
     buildInfoOptions ++= Seq(
@@ -65,14 +66,16 @@ lazy val root = (project in file("."))
           """  public final String sym = ("Foo").intern();""" ::
           """  /** The value is java.time.LocalDate.parse("2021-11-02"). */""" ::
           """  public final java.time.LocalDate now = java.time.LocalDate.parse("2021-11-02");""" ::
+          """  /** The value is java.time.Instant.parse("2021-11-02T01:23:45.678Z"). */""" ::
+          """  public final java.time.Instant instant = java.time.Instant.parse("2021-11-02T01:23:45.678Z");""" ::
           """  /** The value is 1234L. */""" ::
           """  public final Long buildTime = 1234L;""" ::
           targetInfoComment ::
           targetInfo ::
           """""" ::
           """  public String toString() {""" ::
-          """    return String.format("name: %s, scalaVersion: %s, homepage: %s, licenses: %s, apiMappings: %s, isSnapshot: %s, year: %s, sym: %s, now: %s, buildTime: %s, target: %s",""" ::
-          """      name, scalaVersion, homepage, licenses, apiMappings, isSnapshot, year, sym, now, buildTime, target""" ::
+          """    return String.format("name: %s, scalaVersion: %s, homepage: %s, licenses: %s, apiMappings: %s, isSnapshot: %s, year: %s, sym: %s, now: %s, instant: %s, buildTime: %s, target: %s",""" ::
+          """      name, scalaVersion, homepage, licenses, apiMappings, isSnapshot, year, sym, now, instant, buildTime, target""" ::
           """    );""" ::
           """  }""" ::
           """""" ::
@@ -87,6 +90,7 @@ lazy val root = (project in file("."))
           """    m.put("year", year);""" ::
           """    m.put("sym", sym);""" ::
           """    m.put("now", now);""" ::
+          """    m.put("instant", instant);""" ::
           """    m.put("buildTime", buildTime);""" ::
           """    m.put("target", target);""" ::
           """    return java.util.Collections.unmodifiableMap(m);""" ::

--- a/src/sbt-test/sbt-buildinfo/javastaticfieldsrenderer/build.sbt
+++ b/src/sbt-test/sbt-buildinfo/javastaticfieldsrenderer/build.sbt
@@ -25,6 +25,7 @@ lazy val root = (project in file("."))
       "year" -> 2012,
       "sym" -> 'Foo,
       "now" -> java.time.LocalDate.parse("2021-11-02"),
+      "instant" -> java.time.Instant.parse("2021-11-02T01:23:45.678Z"),
       BuildInfoKey.action("buildTime") { 1234L },
       target),
     buildInfoOptions ++= Seq(
@@ -63,14 +64,16 @@ lazy val root = (project in file("."))
           """  public static final String sym = ("Foo").intern();""" ::
           """  /** The value is java.time.LocalDate.parse("2021-11-02"). */""" ::
           """  public static final java.time.LocalDate now = java.time.LocalDate.parse("2021-11-02");""" ::
+          """  /** The value is java.time.Instant.parse("2021-11-02T01:23:45.678Z"). */""" ::
+          """  public static final java.time.Instant instant = java.time.Instant.parse("2021-11-02T01:23:45.678Z");""" ::
           """  /** The value is 1234L. */""" ::
           """  public static final Long buildTime = 1234L;""" ::
           targetInfoComment ::
           targetInfo ::
           """""" ::
           """  public static String makeString() {""" ::
-          """    return String.format("name: %s, scalaVersion: %s, homepage: %s, licenses: %s, apiMappings: %s, isSnapshot: %s, year: %s, sym: %s, now: %s, buildTime: %s, target: %s",""" ::
-          """      name, scalaVersion, homepage, licenses, apiMappings, isSnapshot, year, sym, now, buildTime, target""" ::
+          """    return String.format("name: %s, scalaVersion: %s, homepage: %s, licenses: %s, apiMappings: %s, isSnapshot: %s, year: %s, sym: %s, now: %s, instant: %s, buildTime: %s, target: %s",""" ::
+          """      name, scalaVersion, homepage, licenses, apiMappings, isSnapshot, year, sym, now, instant, buildTime, target""" ::
           """    );""" ::
           """  }""" ::
           """""" ::
@@ -85,6 +88,7 @@ lazy val root = (project in file("."))
           """    m.put("year", year);""" ::
           """    m.put("sym", sym);""" ::
           """    m.put("now", now);""" ::
+          """    m.put("instant", instant);""" ::
           """    m.put("buildTime", buildTime);""" ::
           """    m.put("target", target);""" ::
           """    return java.util.Collections.unmodifiableMap(m);""" ::

--- a/src/sbt-test/sbt-buildinfo/javastaticfieldsrenderer/build.sbt
+++ b/src/sbt-test/sbt-buildinfo/javastaticfieldsrenderer/build.sbt
@@ -24,6 +24,7 @@ lazy val root = (project in file("."))
       isSnapshot,
       "year" -> 2012,
       "sym" -> 'Foo,
+      "now" -> java.time.LocalDate.parse("2021-11-02"),
       BuildInfoKey.action("buildTime") { 1234L },
       target),
     buildInfoOptions ++= Seq(
@@ -60,14 +61,16 @@ lazy val root = (project in file("."))
           """  public static final Integer year = 2012;""" ::
           """  /** The value is ("Foo").intern(). */""" ::
           """  public static final String sym = ("Foo").intern();""" ::
+          """  /** The value is java.time.LocalDate.parse("2021-11-02"). */""" ::
+          """  public static final java.time.LocalDate now = java.time.LocalDate.parse("2021-11-02");""" ::
           """  /** The value is 1234L. */""" ::
           """  public static final Long buildTime = 1234L;""" ::
           targetInfoComment ::
           targetInfo ::
           """""" ::
           """  public static String makeString() {""" ::
-          """    return String.format("name: %s, scalaVersion: %s, homepage: %s, licenses: %s, apiMappings: %s, isSnapshot: %s, year: %s, sym: %s, buildTime: %s, target: %s",""" ::
-          """      name, scalaVersion, homepage, licenses, apiMappings, isSnapshot, year, sym, buildTime, target""" ::
+          """    return String.format("name: %s, scalaVersion: %s, homepage: %s, licenses: %s, apiMappings: %s, isSnapshot: %s, year: %s, sym: %s, now: %s, buildTime: %s, target: %s",""" ::
+          """      name, scalaVersion, homepage, licenses, apiMappings, isSnapshot, year, sym, now, buildTime, target""" ::
           """    );""" ::
           """  }""" ::
           """""" ::
@@ -81,6 +84,7 @@ lazy val root = (project in file("."))
           """    m.put("isSnapshot", isSnapshot);""" ::
           """    m.put("year", year);""" ::
           """    m.put("sym", sym);""" ::
+          """    m.put("now", now);""" ::
           """    m.put("buildTime", buildTime);""" ::
           """    m.put("target", target);""" ::
           """    return java.util.Collections.unmodifiableMap(m);""" ::

--- a/src/sbt-test/sbt-buildinfo/simple/build.sbt
+++ b/src/sbt-test/sbt-buildinfo/simple/build.sbt
@@ -21,6 +21,7 @@ lazy val root = (project in file("."))
       isSnapshot,
       "year" -> 2012,
       "sym" -> 'Foo,
+      "now" -> java.time.LocalDate.parse("2021-11-02"),
       BuildInfoKey.action("buildTime") { 1234L },
       TaskKey[Classpath]("someCp"),
       target
@@ -60,6 +61,8 @@ lazy val root = (project in file("."))
              """  val year: scala.Int = 2012""" ::
              """  /** The value is scala.Symbol("Foo"). */""" ::
              """  val sym: scala.Symbol = scala.Symbol("Foo")""" ::
+             """  /** The value is java.time.LocalDate.parse("2021-11-02"). */""" ::
+             """  val now: java.time.LocalDate = java.time.LocalDate.parse("2021-11-02")""" ::
              """  /** The value is 1234L. */""" ::
              """  val buildTime: scala.Long = 1234L""" ::
              """  /** The value is scala.collection.immutable.Seq(new java.io.File("/tmp/f.txt")). */""" ::
@@ -67,8 +70,8 @@ lazy val root = (project in file("."))
              targetInfoComment ::
              targetInfo :: // """
              """  override val toString: String = {""" ::
-             """    "name: %s, projectVersion: %s, scalaVersion: %s, ivyXML: %s, homepage: %s, licenses: %s, apiMappings: %s, isSnapshot: %s, year: %s, sym: %s, buildTime: %s, someCp: %s, target: %s".format(""" ::
-             """      name, projectVersion, scalaVersion, ivyXML, homepage, licenses, apiMappings, isSnapshot, year, sym, buildTime, someCp, target""" ::
+             """    "name: %s, projectVersion: %s, scalaVersion: %s, ivyXML: %s, homepage: %s, licenses: %s, apiMappings: %s, isSnapshot: %s, year: %s, sym: %s, now: %s, buildTime: %s, someCp: %s, target: %s".format(""" ::
+             """      name, projectVersion, scalaVersion, ivyXML, homepage, licenses, apiMappings, isSnapshot, year, sym, now, buildTime, someCp, target""" ::
              """    )""" ::
              """  }""" ::
              """}""" ::


### PR DESCRIPTION
As part of our project we tag the release date of each of our components, but we'd like to operate on Java Time classes. This PR adds both `java.time.LocalDate` and `java.time.Instant`.
Due to backwards compatibility I decided _not_ to modify the behavior of `BuildInfoOption.BuildTime`  