### PR TITLE
Replace obsolete Bintray badge with Scaladex version

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -10,7 +10,7 @@ Latest Stable
 
 For sbt 1.x add sbt-buildinfo as a dependency in `project/plugins.sbt`:
 
-![Bintray version](https://img.shields.io/bintray/v/eed3si9n/sbt-plugins/sbt-buildinfo.svg)
+[![sbt-buildinfo Scala version support](https://index.scala-lang.org/sbt/sbt-buildinfo/sbt-buildinfo/latest-by-scala-version.svg?targetType=Sbt)](https://index.scala-lang.org/sbt/sbt-buildinfo/sbt-buildinfo)
 
 ```scala
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "x.y.z")


### PR DESCRIPTION
Unfortunately the Bintray badge on the readme just reads [_'no longer available'_](https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/) these days:

![Bintray version](https://img.shields.io/bintray/v/eed3si9n/sbt-plugins/sbt-buildinfo.svg)

However, this new Scaladex badge can replace the old Bintray badge - it summarises which versions of sbt are supported by sbt-buildinfo (and what the latest sbt-buildinfo version is for each of those sbt versions):

[![sbt-buildinfo Scala version support](https://index.scala-lang.org/sbt/sbt-buildinfo/sbt-buildinfo/latest-by-scala-version.svg?targetType=Sbt)](https://index.scala-lang.org/sbt/sbt-buildinfo/sbt-buildinfo)

More details on the badge format here: https://github.com/scalacenter/scaladex/pull/660 (with sbt-focused support in https://github.com/scalacenter/scaladex/pull/674).