### PR TITLE
Bumped version to 0.11.0 in README and built.sbt.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -16,7 +16,7 @@ For sbt 1.x add sbt-buildinfo as a dependency in `project/plugins.sbt`:
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "x.y.z")
 ```
 
-- For `sbt >= 0.13.6`, see [0.10.0](https://github.com/sbt/sbt-buildinfo/tree/v0.10.0).
+- For `sbt >= 0.13.6`, see [0.11.0](https://github.com/sbt/sbt-buildinfo/tree/v0.11.0).
 - For `sbt < 0.13.6`, see [0.3.2](https://github.com/sbt/sbt-buildinfo/tree/0.3.2).
 
 Usage

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ ThisBuild / organization := "com.eed3si9n"
 ThisBuild / dynverSonatypeSnapshots := true
 ThisBuild / version := {
   val orig = (ThisBuild / version).value
-  if (orig.endsWith("-SNAPSHOT")) "0.10.0-SNAPSHOT"
+  if (orig.endsWith("-SNAPSHOT")) "0.11.0-SNAPSHOT"
   else orig
 }
 


### PR DESCRIPTION
@eed3si9n Bumped version numbers in `build.sbt` (for snapshot builds) and in the `README.markdow` file.