### PR TITLE
update CI to enable easier publishing

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,20 +21,11 @@ jobs:
       JAVA_OPTS: -Xms800M -Xmx1G -Xss2M -XX:ReservedCodeCacheSize=128M -Dfile.encoding=UTF-8
       JVM_OPTS: -Xms800M -Xmx1G -Xss2M -XX:ReservedCodeCacheSize=128M -Dfile.encoding=UTF-8
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-java@v2
+    - uses: actions/checkout@v3
+    - uses: actions/setup-java@v3
       with:
         distribution: "${{ matrix.distribution }}"
         java-version: "${{ matrix.java }}"
-    - uses: coursier/cache-action@v6
+        cache: "sbt"
     - shell: bash
       run: sbt -v clean test scripted
-    - shell: bash
-      run: |
-        rm -rf "$HOME/.sbt/scripted/" || true
-        rm -rf "$HOME/.ivy2/local" || true
-        rm -r $(find $HOME/.sbt/boot -name "*-SNAPSHOT") || true
-        find $HOME/Library/Caches/Coursier/v1        -name "ivydata-*.properties" -delete || true
-        find $HOME/.ivy2/cache                       -name "ivydata-*.properties" -delete || true
-        find $HOME/.cache/coursier/v1                -name "ivydata-*.properties" -delete || true
-        find $HOME/.sbt                              -name "*.lock"               -delete || true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,31 @@
+name: Publish
+
+on:
+  push:
+    branches:
+      - main
+    tags: ["**"]
+  release:
+    types: [published]
+
+jobs:
+  publish-artifacts:
+    runs-on: ubuntu-22.04
+    if: ${{ github.repository_owner == 'sbt' }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '8'
+          cache: 'sbt'
+
+      - name: Publish artifacts
+        run: sbt ci-release
+        env:
+          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+          PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
+          PGP_SECRET: ${{ secrets.PGP_SECRET }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,7 +3,7 @@ name: Publish
 on:
   push:
     branches:
-      - main
+      - develop
     tags: ["**"]
   release:
     types: [published]

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,11 @@
 ThisBuild / organization := "com.eed3si9n"
 
+ThisBuild / version := {
+  val orig = (ThisBuild / version).value
+  if (orig.endsWith("-SNAPSHOT")) "0.11.0-SNAPSHOT"
+  else orig
+}
+
 lazy val root = (project in file("."))
   .enablePlugins(SbtPlugin)
   .settings(

--- a/build.sbt
+++ b/build.sbt
@@ -1,10 +1,4 @@
 ThisBuild / organization := "com.eed3si9n"
-ThisBuild / dynverSonatypeSnapshots := true
-ThisBuild / version := {
-  val orig = (ThisBuild / version).value
-  if (orig.endsWith("-SNAPSHOT")) "0.11.0-SNAPSHOT"
-  else orig
-}
 
 lazy val root = (project in file("."))
   .enablePlugins(SbtPlugin)
@@ -38,13 +32,4 @@ ThisBuild / developers := List(
 )
 ThisBuild / description := "sbt plugin to generate build info"
 ThisBuild / licenses := Seq("MIT License" -> url("https://github.com/sbt/sbt-buildinfo/blob/master/LICENSE"))
-ThisBuild / pomIncludeRepository := { _ =>
-  false
-}
-ThisBuild / publishTo := {
-  val nexus = "https://oss.sonatype.org/"
-  if (isSnapshot.value) Some("snapshots" at nexus + "content/repositories/snapshots")
-  else Some("releases" at nexus + "service/local/staging/deploy/maven2")
-}
-ThisBuild / publishMavenStyle := true
 ThisBuild / homepage := Some(url("https://github.com/sbt/sbt-buildinfo"))

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.geirsson" % "sbt-ci-release" % "1.5.3")
+addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.5.10")


### PR DESCRIPTION
This updates a few things related to the CI.

- Bumps the version of sbt-ci-release to the newly published one in the new org
- Sets up publishing in CI
- Adds in dependabot to keep actions up to date
- Simplifies existing CI to use actions/java sbt cache
- Removes some unnecessary stuff from the build file

You'll need to ensure the following secrets exist for this repo:

```
SONATYPE_USERNAME
SONATYPE_PASSWORD
PGP_PASSPHRASE
PGP_SECRET
```