### PR TITLE
deps: update sbt version to 1.8.2

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.6.2
+sbt.version=1.8.2

--- a/src/test/scala/sbtbuildinfo/BuildInfoKeySpec.scala
+++ b/src/test/scala/sbtbuildinfo/BuildInfoKeySpec.scala
@@ -1,7 +1,7 @@
 package sbtbuildinfo
 
 import sbt._, Keys._
-import BuildInfoPlugin.autoImport._
+import BuildInfoPlugin.autoImport.buildInfoKeys
 
 /** This is a compile-only test of the BuildInfoKey syntax/macros. */
 object BuildInfoKeySpec {


### PR DESCRIPTION
I also noticed that this wasn't included in https://github.com/VirtusLab/scala-steward-repos/blob/main/repos-github.md. Would you like me to add it there to get these updates automatically in the future?